### PR TITLE
Store resized images url into DB

### DIFF
--- a/admin/client/components/ImageGrid.js
+++ b/admin/client/components/ImageGrid.js
@@ -1,6 +1,7 @@
 'use strict';
 import { shallowEqual } from 'react-pure-render';
 import { Pill } from 'elemental';
+import _ from 'lodash';
 import objectAssign from 'object-assign';
 import React from 'react';
 
@@ -142,7 +143,7 @@ class ImageGrid extends React.Component {
                     link={image.link}
                     onClick={this._handleClick.bind(this, image)}
                     padding={padding}
-                    url={image.url}
+                    url={image.src}
                     width={width}
                 />
             );

--- a/admin/client/components/ImageSelector.js
+++ b/admin/client/components/ImageSelector.js
@@ -118,14 +118,6 @@ class ImageSelector extends React.Component {
                 }
                 this.state.totalImages = data.count;
                 resolve(data.results.map(function(result) {
-                    let url = _.get(result, ['fields', 'image', 'url'], '');
-                    if (url) {
-                        // use suffix with mobile url
-                        let matches = url.match(/^(http\:\/\/|https\:\/\/)(.*)\.(\w+?)$/)
-                        if (matches) {
-                            result.fields.image.url = matches[1] + matches[2] + '-mobile.' + matches[3];
-                        }
-                    }
                     const image = Object.assign({}, result.fields.image, {id: result.id});
                     return image;
                 }));

--- a/admin/client/components/ImageSelector.js
+++ b/admin/client/components/ImageSelector.js
@@ -118,7 +118,11 @@ class ImageSelector extends React.Component {
                 }
                 this.state.totalImages = data.count;
                 resolve(data.results.map(function(result) {
-                    const image = Object.assign({}, result.fields.image, {id: result.id});
+                    let image = _.get(result, [ 'fields', 'image'], {})
+                    // use desktop version url for rendering
+                    let resizedUrl = _.get(image, ['resizedTargets', 'desktop', 'url' ], image.url)
+                    _.set(image, [ 'src' ], resizedUrl);
+                    image = Object.assign(image, {id: result.id});
                     return image;
                 }));
             });

--- a/admin/client/components/ImagesEditor.js
+++ b/admin/client/components/ImagesEditor.js
@@ -159,7 +159,7 @@ class DnDContainer extends Component {
                         onChange={this._handleChange.bind(this, image)}
                         onRemove={this._handleRemove.bind(this, image)}
                         padding={0}
-                        url={image.url}
+                        url={image.src}
                         style={{border: '1px solid gainsboro'}}
                     >
                         <FormField key={image.id} label="" htmlFor="image-caption-input" style={{paddingTop: '5px'}}>

--- a/fields/types/html/AtomicBlockProcessor.js
+++ b/fields/types/html/AtomicBlockProcessor.js
@@ -27,29 +27,22 @@ function getImageSize(imageUrl) {
     }
     */
 
-function getResizedImageUrls(imageUrl) {
+function getResizedImageUrls(imageObj) {
     let desktop = '';
     let mobile = '';
     let tablet = '';
-    // TODO check url pattern
-    if (imageUrl && typeof imageUrl === 'string') {
-        const matched = imageUrl.match(/(\.[^.]+)?$/);
-        let ext = '';
-        let url = '';
-        if (matched !== null) {
-            url = imageUrl.substr(0, matched.index);
-            ext = matched[0];
-        } else {
-            url = imageUrl;
-        }
-        desktop = url + '-desktop' + ext;
-        mobile = url + '-mobile' + ext;
-        tablet = url + '-tablet' + ext;
+    let original = '';
+    if (imageObj){
+        desktop = _.get(imageObj, [ 'resizedTargets', 'desktop', 'url' ], imageObj.url);
+        mobile = _.get(imageObj, [ 'resizedTargets', 'mobile', 'url' ], imageObj.url);
+        tablet = _.get(imageObj, [ 'resizedTargets', 'tablet', 'url' ], imageObj.url);
+        original =  _.get(imageObj, [ 'url' ]);
     }
     return {
         desktop,
         mobile,
-        tablet
+        tablet,
+        original
     };
 }
 
@@ -93,11 +86,10 @@ const processor = {
     convertImageBlock(entity) {
         let image = entity.data || {};
         let rtn = {};
-        let urls = getResizedImageUrls(image.url);
+        let urls = getResizedImageUrls(image);
         Object.keys(urls).forEach((device) => {
             rtn[device] = _.merge({url: urls[device]}, _.pick(image, ['id', 'description']));
         });
-        _.set(rtn, 'original', image);
         return rtn;
     },
 
@@ -109,11 +101,10 @@ const processor = {
     _convertImagesBlock(images) {
         return images.map((image) => {
             let imageSet = {};
-            let urls = getResizedImageUrls(image.url);
+            let urls = getResizedImageUrls(image);
             Object.keys(urls).forEach((device) => {
                 imageSet[device] = _.merge({url: urls[device]}, _.pick(image, ['id', 'description']));
             });
-            _.set(imageSet, 'original', image);
             return imageSet;
         });
     }

--- a/fields/types/html/CONSTANT.js
+++ b/fields/types/html/CONSTANT.js
@@ -15,7 +15,7 @@ const ENTITY = {
     },
     image: {
         type: 'image',
-        imageRequiredProps: ['id', 'url', 'description', 'width', 'height']
+        imageRequiredProps: ['id', 'url', 'description', 'width', 'height', 'resizedTargets']
     },
     imageDiff: {
         type: 'imageDiff'

--- a/fields/types/html/image-diff/image-diff-block.js
+++ b/fields/types/html/image-diff/image-diff-block.js
@@ -1,6 +1,6 @@
 'use strict';
-
 import { Entity } from 'draft-js';
+import _ from 'lodash';
 import classNames from 'classnames';
 import ImagesDiff from '../../../../admin/client/components/ImagesDiff';
 import React from 'react';
@@ -14,9 +14,14 @@ export default class ImageDiffBlock extends SlideshowBlock{
   render() {
     let { editMode, images } = this.state;
     images = !this._isEmptyArray(images) ? images : this._getImagesFromEntity();
-    if (!images) {
+    if (!images || !Array.isArray(images)) {
         return null;
     }
+
+    images = images.map((image) => {
+      _.set(image, [ 'src' ], _.get(image, [ 'resizedTargets', 'desktop', 'url' ]))
+      return image;
+    })
 
     const EditBlock = editMode ? this._renderImageSelector({
           apiPath: 'images',
@@ -31,8 +36,8 @@ export default class ImageDiffBlock extends SlideshowBlock{
       <div className={classNames(this.props.className, 'imageWrapper')}
           style={{position:"relative"}}>
         <ImagesDiff
-            after={images[1].url}
-            before={images[0].url}
+            after={images[1].src}
+            before={images[0].src}
         />
         {EditBlock}
         {this.props.children}

--- a/fields/types/html/image/image-block.js
+++ b/fields/types/html/image/image-block.js
@@ -76,6 +76,8 @@ export default class ImageBlock extends React.Component {
           return null;
       }
 
+      image.src = _.get(image, ['resizedTargets', 'desktop', 'url'], image.url)
+
       const EditBlock = editMode ? this._renderImageSelector({
           apiPath: 'images',
           isSelectionOpen: true,
@@ -86,12 +88,13 @@ export default class ImageBlock extends React.Component {
       }) : null;
 
       className = `imageWrapper ${className}`;
+
       return (
           <div
               className={className}
               contentEditable={false}
               >
-              <img src={image.url} width="100%" onClick={this.handleClick} style={{cursor: "pointer"}}/>
+              <img src={image.src} width="100%" onClick={this.handleClick} style={{cursor: "pointer"}}/>
               <figcaption>{image.description}</figcaption>
               {EditBlock}
               {this.props.children}


### PR DESCRIPTION
1. store ```resizedTargets``` into DB.
2. Use desktop version for rendering in the keystone, because the original image is too big to render smoothly.

@hcchien 