### PR TITLE
use mobile version image for rendering image list

### DIFF
--- a/fields/types/gcsimage/GcsImageColumn.js
+++ b/fields/types/gcsimage/GcsImageColumn.js
@@ -1,9 +1,10 @@
 var React = require('react');
+var _ = require('lodash');
 
 var GcsImageColumn = React.createClass({
 	render: function () {
 		var value = this.props.data.fields[this.props.col.path] || {};
-		var isVal = value.url ? value.url : null;
+		var isVal = _.get(value, [ 'resizedTargets', 'mobile', 'url' ], value.url);
 		return (
 			<td className="ItemList__col">
               <div className="ItemList__value ItemList__value--gcs-image"><a href={isVal} target="_blank"><img src={isVal} height="150" width="150"/></a></div>


### PR DESCRIPTION
http://keystone.twreporter.org/keystone/images/
right now, this page is very slow because of image size.
Hence, we need to use mobile version image to render the image list.
@hcchien 