### PR TITLE
Annotation component

### DIFF
--- a/admin/public/styles/draftjs/rich-editor.less
+++ b/admin/public/styles/draftjs/rich-editor.less
@@ -43,9 +43,49 @@
         padding: 20px;
       }
 
-      figure[data-block='true'] {
-        margin: 0 0 40px 0;
+	  figure[data-block='true'] {
+		  margin: 0 0 40px 0;
+	  }
+
+    .annotation {
+      .annotation-html {
+        h3, h4 {
+          color: #262626;
+        }
+        div {
+          font-size: 15px;
+          color: #808080;
+          margin-bottom: 15px;
+        }
       }
+      .indicator {
+        // circle
+        width: 18px;
+        height: 18px;
+        background-color: red;
+        border-radius: 9px;
+        position: relative;
+        top: -3px;
+        display: inline-block;
+        margin-left: 3px;
+        // down triangle
+        &::after {
+          content: "";
+          position: absolute;
+          top: 7px;
+          left: 3px;
+          border-style: solid;
+          border-width: 6px 6px 0;
+          border-color: white transparent;
+        }
+
+        // up triangle
+        &.up::after {
+          top: 5px;
+          border-width: 0 6px 6px;
+        }
+      }
+    }
 
       min-height: 100px;
     }

--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -155,10 +155,9 @@ module.exports = Field.create({
 		this._toggleAtomicBlock(entity, audio);
 	},
 
-	_toggleLink (entity, value) {
-		const { url, text } = value;
-		const entityKey = url !== '' ? Entity.create(entity, 'IMMUTABLE', { text: text || url, url: url }) : null;
-		this._toggleTextWithEntity(entityKey, text || url);
+	_toggleInlineEntity (entity, value) {
+		const entityKey = Entity.create(entity, 'IMMUTABLE', value);
+		this._toggleTextWithEntity(entityKey, _.get(value, 'text'));
 	},
 
 	_toggleImage (entity, value) {
@@ -190,14 +189,14 @@ module.exports = Field.create({
 		switch (entity) {
 			case ENTITY.audio.type:
 				return this._toggleAudio(entity, value);
-			case ENTITY.annotation.type:
 			case ENTITY.blockQuote.type:
 			case ENTITY.infobox.type:
 			case ENTITY.embeddedCode.type:
 			case ENTITY.youtube.type:
 				return this._toggleAtomicBlock(entity, value);
+			case ENTITY.annotation.type:
 			case ENTITY.link.type:
-				return this._toggleLink(entity, value);
+				return this._toggleInlineEntity(entity, value);
 			case ENTITY.image.type:
 				return this._toggleImage(entity, value);
 			case ENTITY.slideshow.type:

--- a/fields/types/html/editor/annotation/annotation-decorator.js
+++ b/fields/types/html/editor/annotation/annotation-decorator.js
@@ -1,32 +1,49 @@
+'use strict';
 import { Entity } from 'draft-js';
 import ENTITY from '../entities';
 import React from 'react';
+import classNames from 'classnames';
 class Annotation extends React.Component {
 	constructor (props) {
 		super(props);
 		this.state = {
-			expanded: false,
+			isExpanded: false,
 		};
 		this.handleExpand = this._handleExpand.bind(this);
 	}
 
 	_handleExpand (e) {
 		this.setState({
-			expanded: !this.state.expanded,
+			isExpanded: !this.state.isExpanded,
 		});
 	}
 
 	render () {
-		// TBD Use react-article-components to render annotation component
 		const { annotation, pureAnnotationText, text } = Entity.get(this.props.entityKey).getData();
 		return (
-			<abbr title={pureAnnotationText} onClick={this.handleExpand}>
-				<span>
+			<abbr
+				className="annotation"
+				title={pureAnnotationText}
+				onClick={this.handleExpand}
+				style={{ cursor: 'pointer', borderBottom: 0 }}
+			>
+				<span
+					style={{ color: 'red' }}
+				>
 					{text}
+					<span className={classNames(this.state.isExpanded ? 'up' : '', 'indicator')}/>
 				</span>
-				<span dangerouslySetInnerHTML={{ __html: annotation }} style={{
-					display: this.state.expanded ? 'block' : 'none',
-				}} />
+				<span
+					className="annotation-html"
+					dangerouslySetInnerHTML={{ __html: annotation }}
+					style={{
+						display: this.state.isExpanded ? 'block' : 'none',
+						backgroundColor: 'white',
+						padding: '16px',
+						fontSize: '15px',
+						lineHeight: 1.5,
+					}}
+				/>
 			</abbr>
 		);
 	}

--- a/fields/types/html/editor/annotation/annotation-decorator.js
+++ b/fields/types/html/editor/annotation/annotation-decorator.js
@@ -1,0 +1,49 @@
+import { Entity } from 'draft-js';
+import ENTITY from '../entities';
+import React from 'react';
+class Annotation extends React.Component {
+	constructor (props) {
+		super(props);
+		this.state = {
+			expanded: false,
+		};
+		this.handleExpand = this._handleExpand.bind(this);
+	}
+
+	_handleExpand (e) {
+		this.setState({
+			expanded: !this.state.expanded,
+		});
+	}
+
+	render () {
+		// TBD Use react-article-components to render annotation component
+		const { annotation, pureAnnotationText, text } = Entity.get(this.props.entityKey).getData();
+		return (
+			<abbr title={pureAnnotationText} onClick={this.handleExpand}>
+				<span>
+					{text}
+				</span>
+				<span dangerouslySetInnerHTML={{ __html: annotation }} style={{
+					display: this.state.expanded ? 'block' : 'none',
+				}} />
+			</abbr>
+		);
+	}
+
+}
+
+function findLinkEntities (contentBlock, callback) {
+	contentBlock.findEntityRanges(
+		(character) => {
+			const entityKey = character.getEntity();
+			return (
+				entityKey !== null
+				&& Entity.get(entityKey).getType() === ENTITY.annotation.type
+			);
+		},
+		callback
+	);
+}
+
+export default { strategy: findLinkEntities, component: Annotation };

--- a/fields/types/html/editor/annotation/annotation-editing-block.js
+++ b/fields/types/html/editor/annotation/annotation-editing-block.js
@@ -30,8 +30,10 @@ class AnnotationEditingBlock extends EntityEditingBlockMixin(React.Component) {
 		const content = convertToRaw(editorState.getCurrentContent());
 		const cHtml = DraftConverter.convertToHtml(content);
 		return {
+			// annotated text
 			text: fields.text.value,
 			annotation: cHtml,
+			pureAnnotationText: _.get(content, ['blocks', 0, 'text'], ''),
 			draftRawObj: content,
 		};
 	}

--- a/fields/types/html/editor/annotation/annotation-editing-block.js
+++ b/fields/types/html/editor/annotation/annotation-editing-block.js
@@ -28,7 +28,7 @@ class AnnotationEditingBlock extends EntityEditingBlockMixin(React.Component) {
 	_decomposeEditingFields (fields) {
 		let { editorState } = this.state;
 		const content = convertToRaw(editorState.getCurrentContent());
-		const cHtml = DraftConverter.convertToHtml(content);
+		const cHtml = DraftConverter.convertToHtml(content, { unstyled: `<div>%content%</div>` });
 		return {
 			// annotated text
 			text: fields.text.value,

--- a/fields/types/html/editor/atomic-block-processor.js
+++ b/fields/types/html/editor/atomic-block-processor.js
@@ -11,7 +11,6 @@ const processor = {
 		const entity = entityMap[entityRange.key];
 		const type = entity && entity.type;
 		switch (type) {
-			case ENTITY.annotation.type:
 			case ENTITY.audio.type:
 			case ENTITY.blockQuote.type:
 			case ENTITY.embeddedCode.type:

--- a/fields/types/html/editor/base/atomic-block-switcher.js
+++ b/fields/types/html/editor/base/atomic-block-switcher.js
@@ -3,7 +3,6 @@
 import { Entity } from 'draft-js';
 import _ from 'lodash';
 import ENTITY from '../entities';
-import AnnotationBlock from '../annotation/annotation-block';
 import AudioBlock from '../audio/audio-block';
 import BlockQuoteBlock from '../quote/block-quote-block';
 import EmbeddedCodeBlock from '../embedded-code/embedded-code-block';
@@ -75,14 +74,6 @@ class AtomicBlockSwitcher extends React.Component {
 
 
 		switch (type) {
-			case ENTITY.annotation.type:
-				BlockComponent = AnnotationBlock;
-				if (device === 'mobile') {
-					style = mobileStyle;
-				} else {
-					style = tabletMinStyle;
-				}
-				break;
 			case ENTITY.audio.type:
 				BlockComponent = AudioBlock;
 				if (device === 'mobile') {

--- a/fields/types/html/editor/draft-converter.js
+++ b/fields/types/html/editor/draft-converter.js
@@ -9,14 +9,18 @@ import * as InlineStylesProcessor from './inline-styles-processor';
 const annotationIndicatorPrefix = '__ANNOTATION__=';
 
 let defaultBlockTagMap = {
-	'code-block': `<code>%content%</code>\n`,
-	'default': `<p>%content%</p>\n`,
-	'header-one': `<h1>%content%</h1>\n`,
-	'header-two': `<h1>%content%</h1>\n`,
-	'ordered-list-item': `<li>%content%</li>\n`,
-	'unordered-list-item': `<li>%content%</li>\n`,
-	'atomic': `<div>%content%</div>\n`,
-	'unstyled': `<p>%content%</p>\n`,
+	'code-block': `<code>%content%</code>`,
+	'default': `<p>%content%</p>`,
+	'header-one': `<h1>%content%</h1>`,
+	'header-two': `<h2>%content%</h2>`,
+	'header-three': `<h3>%content%</h3>`,
+	'header-four': `<h4>%content%</h4>`,
+	'header-five': `<h5>%content%</h5>`,
+	'header-six': `<h6>%content%</h6>`,
+	'ordered-list-item': `<li>%content%</li>`,
+	'unordered-list-item': `<li>%content%</li>`,
+	'atomic': `<div>%content%</div>`,
+	'unstyled': `<p>%content%</p>`,
 };
 
 let inlineTagMap = {
@@ -138,7 +142,7 @@ function convertBlocksToApiData (blocks, entityMap, entityTagMap) {
 }
 
 function convertRawToHtml (raw, blockTagMap, entityTagMap) {
-	blockTagMap = blockTagMap || defaultBlockTagMap;
+	blockTagMap = _.merge({}, defaultBlockTagMap, blockTagMap);
 	entityTagMap = entityTagMap || defaultEntityTagMap;
 	let html = '';
 	raw = raw || {};
@@ -154,10 +158,9 @@ function convertRawToApiData (raw) {
 	const blocks = Array.isArray(raw.blocks) ? raw.blocks : [];
 	const entityMap = typeof raw.entityMap === 'object' ? raw.entityMap : {};
 	let entityTagMap = _.merge({}, defaultEntityTagMap, {
-
 		// special handling for annotation entity
 		// annotation entity data will be included in the speical comment.
-		annotation: [`<!--${annotationIndicatorPrefix}<%= JSON.stringify(data) %>`, '-->'],
+		annotation: [`<!--${annotationIndicatorPrefix}<%= JSON.stringify(data) %>--><!--`, '-->'],
 	});
 	apiData = convertBlocksToApiData(blocks, entityMap, entityTagMap);
 	return apiData;

--- a/fields/types/html/editor/editor-buttons.js
+++ b/fields/types/html/editor/editor-buttons.js
@@ -125,13 +125,14 @@ export const EntityButtons = (props) => {
 				return (
 					<AnnotationBt
 						active={active}
+						annotation={data ? data.annotation : ''}
+						draftRawObj={data ? data.draftRawObj : null}
+						icon="fa-pencil-square-o"
+						iconText=""
 						key={entity}
 						label={entity}
 						onToggle={onToggle}
 						text={data ? data.text : selectedText}
-						annotation={data ? data.annotation : ''}
-						icon="fa-pencil-square-o"
-						iconText=""
 					/>
 				);
 			case ENTITY.audio.type:

--- a/fields/types/html/editor/entity-decorator.js
+++ b/fields/types/html/editor/entity-decorator.js
@@ -1,10 +1,11 @@
 'use strict';
 
 import { CompositeDecorator } from 'draft-js';
+import React from 'react'; // eslint-disable-line no-unused-vars
+import annotationDecorator from './annotation/annotation-decorator';
 import linkDecorator from './link/link-decorator';
 import quoteDecorator from './quote/quote-decorator';
-import React from 'react'; // eslint-disable-line no-unused-vars
 
-const decorator = new CompositeDecorator([linkDecorator, quoteDecorator]);
+const decorator = new CompositeDecorator([annotationDecorator, linkDecorator, quoteDecorator]);
 
 export default decorator;

--- a/fields/types/html/editor/inline-styles-processor.js
+++ b/fields/types/html/editor/inline-styles-processor.js
@@ -25,10 +25,10 @@ function _fullfilIntersection (block) {
 			// <strong></strong>  is inline style
 			if (nextEntityOffset >= inlineOffset && nextEntityOffset < (inlineOffset + inlineLength) && (nextEntityOffset + nextEntityLength) > (inlineOffset + inlineLength) // <a><strong></a></strong>
 				&& entityOffset < inlineOffset && (entityOffset + entityLength) > inlineOffset && (entityOffset + entityLength) <= (inlineOffset + inlineLength)) { // <strong><abbr></strong></abbr>
-					// situation: <a><strong></a><abbr></strong></abbr>
-					// should be: <a><strong></strong></a><strong></strong><abbr><strong></strong></abbr>
+				// situation: <a><strong></a><abbr></strong></abbr>
+				// should be: <a><strong></strong></a><strong></strong><abbr><strong></strong></abbr>
 
-					// skip next entity checking
+				// skip next entity checking
 				i = i + 1;
 
 				splitedISInline.push({
@@ -118,9 +118,15 @@ function _entityTag (entityTagMap, entityMap, entityRanges, tagInsertMap = {}) {
 	_.forEach(entityRanges, (range) => {
 		let entity = entityMap[range.key];
 		let tag = entityTagMap[entity.type];
+		let data = entity.data;
 
-		let compiledTag0 = _.template(tag[0], { variable: 'data' })(entity.data);
-		let compiledTag1 = _.template(tag[1], { variable: 'data' })(entity.data);
+		// special case
+		if (entity.type === 'annotation') {
+			data = _.pick(data, 'text', 'annotation', 'pureAnnotationText');
+		}
+
+		let compiledTag0 = _.template(tag[0], { variable: 'data' })(data);
+		let compiledTag1 = _.template(tag[1], { variable: 'data' })(data);
 
 		if (!tagInsertMap[range.offset]) {
 			tagInsertMap[range.offset] = [];
@@ -179,62 +185,6 @@ function convertToHtml (inlineTagMap, entityTagMap, entityMap, block) {
 	return html;
 }
 
-/*
-function convertToApiData (inlineTagMap, entityTagMap, entityMap, block) {
-	if ((!block.inlineStyleRanges && !block.entityRanges)
-		|| (block.inlineStyleRanges.length === 0 && block.entityRanges.length === 0)) {
-		return block.text;
-	}
-	let text = block.text;
-	let entityRanges = block.entityRanges;
-	let splitByEntity = [];
-
-	if (entityRanges.length === 0) {
-		splitByEntity = [{
-			offset: 0,
-			length: text.length,
-			text: text,
-		}];
-	} else {
-		_.forEach(entityRanges, (entityRange) => {
-			let offset = entityRange.offset;
-			let length = entityRange.length;
-
-		});
-	}
-
-	let inlineStyleRanges = _fullfilIntersection(block);
-	tagInsertMap = _inlineTag(inlineTagMap, inlineStyleRanges, tagInsertMap);
-	// sort on position, as we'll need to keep track of offset
-	let orderedKeys = Object.keys(tagInsertMap).sort(function (a, b) {
-		a = Number(a);
-		b = Number(b);
-		if (a > b) {
-			return 1;
-		}
-		if (a < b) {
-			return -1;
-		}
-		return 0;
-	});
-	// insert tags into string, keep track of offset caused by our text insertions
-	let contents = [];
-	let offset = 0;
-	orderedKeys.forEach(function (pos) {
-		let index = Number(pos);
-		tagInsertMap[pos].forEach(function (tag) {
-			contents.push();
-			html = html.substr(0, offset + index)
-				+ tag + html.substr(offset + index);
-			offset += tag.length;
-		});
-	});
-
-	return html;
-}
-*/
-
 export {
-	// convertToApiData,
 	convertToHtml,
 };

--- a/fields/types/html/editor/mixins/entity-editing-block-mixin.js
+++ b/fields/types/html/editor/mixins/entity-editing-block-mixin.js
@@ -30,6 +30,7 @@ let EntityEditingBlock = (superclass) => class extends Component {
 		this._editingFields = this.composeEditingFields(nextProps);
 		this.setState({
 			editingFields: this._editingFields,
+			editorState: this._initEditorState(nextProps.draftRawObj),
 		});
 	}
 

--- a/fields/types/html/editor/mixins/entity-editing-block-mixin.js
+++ b/fields/types/html/editor/mixins/entity-editing-block-mixin.js
@@ -3,7 +3,6 @@ import { Button, FormField, FormInput, Modal } from 'elemental';
 import { convertFromRaw, EditorState, Entity, Modifier, RichUtils } from 'draft-js';
 import { BlockStyleButtons, EntityButtons, InlineStyleButtons } from '../editor-buttons';
 import decorator from '../entity-decorator';
-import quoteTypes from '../quote/quote-types';
 import DraftEditor from '../draft-editor';
 import ENTITY from '../entities';
 import React, { Component } from 'react';
@@ -231,9 +230,8 @@ let EntityEditingBlock = (superclass) => class extends Component {
 
 // block settings
 const BLOCK_TYPES = [
-	{ label: quoteTypes.blockquote.label, style: 'blockquote', icon: 'fa-quote-right', text: ' Block' },
-	{ label: 'H1', style: 'header-one', icon: 'fa-header', text: '1' },
-	{ label: 'H2', style: 'header-two', icon: 'fa-header', text: '2' },
+	{ label: 'H3', style: 'header-three', icon: 'fa-header', text: '3' },
+	{ label: 'H4', style: 'header-four', icon: 'fa-header', text: '4' },
 	{ label: 'OL', style: 'ordered-list-item', icon: 'fa-list-ol', text: '' },
 	{ label: 'UL', style: 'unordered-list-item', icon: 'fa-list-ul', text: '' },
 ];


### PR DESCRIPTION
- Use annotation-decorators to render, not atomic block anymore
- Use ```<abbr>``` tag to convert annotation data into html
- JSON stringify annotation data and put that in the commont in the output
  of data api.
- Set block type as annotation if block contains annotation entity.

@garfieldduck 