### PR TITLE
fix: empty script object when encountering close tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 0.8.0-rc.4
+### Commits
+* [[`d657d505f4`](https://github.com/twreporter/keystone/commit/d657d505f4)] - **fix**: fix indentation (Taylor Fang)
+* [[`f9c7b7e3cd`](https://github.com/twreporter/keystone/commit/f9c7b7e3cd)] - **fix**: address review comment (Taylor Fang)
+* [[`71d705b4a4`](https://github.com/twreporter/keystone/commit/71d705b4a4)] - **fix**: create a new object for each script tag (Taylor Fang)
+
 ## 0.8.0-rc.3
 ### Commits
 * [[`385991a92d`](https://github.com/twreporter/keystone/commit/385991a92d)] - **fix**: downgrade multer to 0.1.8 (nickhsine)

--- a/fields/types/html/editor/atomic-block-processor.js
+++ b/fields/types/html/editor/atomic-block-processor.js
@@ -7,103 +7,103 @@ import merge from 'lodash/merge';
 
 const _ = {
   get,
-  merge
-}
+  merge,
+};
 
 const processor = {
-	convertBlock (entityMap, block) {
-		let alignment = 'center';
-		let content;
-		let entityRange = block.entityRanges[0];
-		let styles = {};
-		const entity = entityMap[entityRange.key];
+  convertBlock (entityMap, block) {
+    let alignment = 'center';
+    let content;
+    let entityRange = block.entityRanges[0];
+    let styles = {};
+    const entity = entityMap[entityRange.key];
 
-		let type = _.get(entity, 'type', '');
+    let type = _.get(entity, 'type', '');
 
-		// backward compatible. Old entity type might be lower case
-		switch (type && type.toUpperCase()) {
-			case ENTITY.BLOCKQUOTE.type:
-				// this is different from default blockquote of draftjs
-				// so we name our specific blockquote as 'quoteby'
-				type = 'quoteby';
-				alignment = entity.data && entity.data.alignment || alignment;
-				content = _.get(entity, 'data');
-				content = Array.isArray(content) ? content : [content];
-				break;
-			case ENTITY.AUDIO.type:
-			case ENTITY.IMAGE.type:
-			case ENTITY.INFOBOX.type:
-			case ENTITY.SLIDESHOW.type:
-			case ENTITY.IMAGEDIFF.type:
-			case ENTITY.YOUTUBE.type:
-				alignment = entity.data && entity.data.alignment || alignment;
-				content = _.get(entity, 'data');
-				content = Array.isArray(content) ? content : [content];
-				break;
-			case ENTITY.IMAGELINK.type:
-				// use Embedded component to dangerouslySetInnerHTML
-				type = ENTITY.EMBEDDEDCODE.type;
-				alignment = entity.data && entity.data.alignment || alignment;
-				let description = _.get(entity, ['data', 'description'], '');
-				let url = _.get(entity, ['data', 'url'], '');
-				content = [{
-					caption: description,
-					embeddedCodeWithoutScript: `<img alt="${description}" src="${url}" class="img-responsive"/>`,
-					url: url,
-				}];
-				break;
-			case ENTITY.EMBEDDEDCODE.type:
-				alignment = entity.data && entity.data.alignment || alignment;
-				let caption = _.get(entity, ['data', 'caption'], '');
-				let embeddedCode = _.get(entity, ['data', 'embeddedCode'], '');
-				let script = {};
-				let scripts = [];
-				let scriptTagStart = false;
-				let height;
-				let width;
-				let parser = new htmlparser.Parser({
-					onopentag: (name, attribs) => {
+    // backward compatible. Old entity type might be lower case
+    switch (type && type.toUpperCase()) {
+      case ENTITY.BLOCKQUOTE.type:
+        // this is different from default blockquote of draftjs
+        // so we name our specific blockquote as 'quoteby'
+        type = 'quoteby';
+        alignment = entity.data && entity.data.alignment || alignment;
+        content = _.get(entity, 'data');
+        content = Array.isArray(content) ? content : [content];
+        break;
+      case ENTITY.AUDIO.type:
+      case ENTITY.IMAGE.type:
+      case ENTITY.INFOBOX.type:
+      case ENTITY.SLIDESHOW.type:
+      case ENTITY.IMAGEDIFF.type:
+      case ENTITY.YOUTUBE.type:
+        alignment = entity.data && entity.data.alignment || alignment;
+        content = _.get(entity, 'data');
+        content = Array.isArray(content) ? content : [content];
+        break;
+      case ENTITY.IMAGELINK.type:
+        // use Embedded component to dangerouslySetInnerHTML
+        type = ENTITY.EMBEDDEDCODE.type;
+        alignment = entity.data && entity.data.alignment || alignment;
+        let description = _.get(entity, ['data', 'description'], '');
+        let url = _.get(entity, ['data', 'url'], '');
+        content = [{
+          caption: description,
+          embeddedCodeWithoutScript: `<img alt="${description}" src="${url}" class="img-responsive"/>`,
+          url: url,
+        }];
+        break;
+      case ENTITY.EMBEDDEDCODE.type:
+        alignment = entity.data && entity.data.alignment || alignment;
+        let caption = _.get(entity, ['data', 'caption'], '');
+        let embeddedCode = _.get(entity, ['data', 'embeddedCode'], '');
+        let script = {};
+        let scripts = [];
+        let scriptTagStart = false;
+        let height;
+        let width;
+        let parser = new htmlparser.Parser({
+          onopentag: (name, attribs) => {
             if (name === 'script') {
-							scriptTagStart = true;
-							script.attribs = attribs;
-						} else if (name === 'iframe') {
-							height = _.get(attribs, 'height', 0);
-							width = _.get(attribs, 'width', 0);
-						}
-					},
-					ontext: (text) => {
-						if (scriptTagStart) {
-							script.text = text;
-						}
-					},
-					onclosetag: (tagname) => {
-						if (tagname === 'script' && scriptTagStart) {
-							scriptTagStart = false;
+              scriptTagStart = true;
+              script.attribs = attribs;
+            } else if (name === 'iframe') {
+              height = _.get(attribs, 'height', 0);
+              width = _.get(attribs, 'width', 0);
+            }
+          },
+          ontext: (text) => {
+            if (scriptTagStart) {
+              script.text = text;
+            }
+          },
+          onclosetag: (tagname) => {
+            if (tagname === 'script' && scriptTagStart) {
+              scriptTagStart = false;
               scripts.push(_.merge({}, script));
               script = {};
-						}
-					},
-				});
-				parser.write(embeddedCode);
-				parser.end();
+            }
+          },
+        });
+        parser.write(embeddedCode);
+        parser.end();
 
-				content = [{
-					caption,
-					embeddedCode,
-					embeddedCodeWithoutScript: embeddedCode.replace(/<script(.+?)\/script>/g, ''),
-					height,
-					scripts,
-					width,
-				}];
+        content = [{
+          caption,
+          embeddedCode,
+          embeddedCodeWithoutScript: embeddedCode.replace(/<script(.+?)\/script>/g, ''),
+          height,
+          scripts,
+          width,
+        }];
 
-				break;
-			default:
-				return;
-		}
+        break;
+      default:
+        return;
+    }
 
-		// block type of api data should be lower case
-		return new ApiDataInstance({ id: block.key, alignment, type: type && type.toLowerCase(), content, styles });
-	},
+    // block type of api data should be lower case
+    return new ApiDataInstance({ id: block.key, alignment, type: type && type.toLowerCase(), content, styles });
+  },
 };
 
 export default processor;

--- a/fields/types/html/editor/atomic-block-processor.js
+++ b/fields/types/html/editor/atomic-block-processor.js
@@ -54,14 +54,15 @@ const processor = {
 				alignment = entity.data && entity.data.alignment || alignment;
 				let caption = _.get(entity, ['data', 'caption'], '');
 				let embeddedCode = _.get(entity, ['data', 'embeddedCode'], '');
-				let script = {};
+				let script;
 				let scripts = [];
 				let scriptTagStart = false;
 				let height;
 				let width;
 				let parser = new htmlparser.Parser({
 					onopentag: (name, attribs) => {
-						if (name === 'script') {
+            if (name === 'script') {
+              script = {};
 							scriptTagStart = true;
 							script.attribs = attribs;
 						} else if (name === 'iframe') {

--- a/fields/types/html/editor/atomic-block-processor.js
+++ b/fields/types/html/editor/atomic-block-processor.js
@@ -1,11 +1,13 @@
 // import sizeOf from 'image-size';
 import ApiDataInstance from './api-data-instance';
 import ENTITY from './entities';
-import htmlparser from 'htmlparser2';
 import get from 'lodash/get';
+import htmlparser from 'htmlparser2';
+import merge from 'lodash/merge';
 
 const _ = {
   get,
+  merge
 }
 
 const processor = {
@@ -54,7 +56,7 @@ const processor = {
 				alignment = entity.data && entity.data.alignment || alignment;
 				let caption = _.get(entity, ['data', 'caption'], '');
 				let embeddedCode = _.get(entity, ['data', 'embeddedCode'], '');
-				let script;
+				let script = {};
 				let scripts = [];
 				let scriptTagStart = false;
 				let height;
@@ -62,7 +64,6 @@ const processor = {
 				let parser = new htmlparser.Parser({
 					onopentag: (name, attribs) => {
             if (name === 'script') {
-              script = {};
 							scriptTagStart = true;
 							script.attribs = attribs;
 						} else if (name === 'iframe') {
@@ -78,7 +79,8 @@ const processor = {
 					onclosetag: (tagname) => {
 						if (tagname === 'script' && scriptTagStart) {
 							scriptTagStart = false;
-							scripts.push(script);
+              scripts.push(_.merge({}, script));
+              script = {};
 						}
 					},
 				});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/keystone",
-  "version": "0.8.0-rc.3",
+  "version": "0.8.0-rc.4",
   "description": "Web Application Framework and Admin GUI / Content Management System built on Express.js and Mongoose",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## Change Reason

When handling embedded blocks, objects in `scripts` array reference to a same object.

For example, if the embedded code is:

```
<div class="infogram-embed" data-id="_/UatSWDwbnebNDg3LGBos" data-type="interactive" data-title="台灣的笑氣（一氧化二氮） 如何非法流入市場？ / 報導者"></div>
<script>text in the first script</script>
<script src="https://get-some-src">text in the second script</script>
```

Since the `script` object which is pushed into `scripts` array refer to same object, this is what `scripts` looks like:

```
scripts: [
                    {
                      attribs: {
                        src: 'https://get-some-src',
                      },
                      text: 'text in the second script'
                    },
                    {
                      attribs: {
                        src: 'https://get-some-src',
                      },
                      text: 'text in the second script'
                    },
]
``` 

And the expected one should be:
```
scripts: [
                    {
                      attribs: {},
                      text: 'text in the first script'
                    },
                    {
                      attribs: {
                        src: 'https://get-some-src',
                      },
                      text: 'text in the second script'
                    },
]
``` 