### PR TITLE
feat: disable autoIndex in production

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -16,6 +16,9 @@ function List (key, options) {
 	var defaultOptions = {
 		schema: {
 			collection: keystone.prefixModel(key),
+  // Disable the autoIndex option in production
+  // https://mongoosejs.com/docs/guide.html#autoIndex
+      autoIndex: keystone.get('env') !== 'production'
 		},
 		noedit: false,
 		nocreate: false,


### PR DESCRIPTION
This patch disables the autoIndex mechanism from the mongoose for
the models update during keystone startups in production.