### PR TITLE
refactor: change the `cookie signin` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ var Keystone = function () {
 	this.set('ssl cert', process.env.SSL_CERT);
 
 	this.set('cookie secret', process.env.COOKIE_SECRET);
-	this.set('cookie signin', (this.get('env') === 'development') ? true : false);
+	this.set('cookie signin', process.env.COOKIE_SIGNIN || true);
 
 	this.set('embedly api key', process.env.EMBEDLY_API_KEY || process.env.EMBEDLY_APIKEY);
 	this.set('mandrill api key', process.env.MANDRILL_API_KEY || process.env.MANDRILL_APIKEY);


### PR DESCRIPTION
This patch enables the cookie signin by default and provide  the
environment variable for fine-grained configuration in runtime.