### PR TITLE
fix: utilize mongoose as session driver

### DIFF
--- a/lib/core/initExpressApp.js
+++ b/lib/core/initExpressApp.js
@@ -1,7 +1,7 @@
 module.exports = function initExpressApp () {
 	if (this.app) return this;
 	this.initDatabase();
-	this.initExpressSession();
+	this.initExpressSession(this.mongoose);
 	this.app = require('../../server/createApp')(this);
 	return this;
 };

--- a/lib/core/initExpressSession.js
+++ b/lib/core/initExpressSession.js
@@ -3,7 +3,7 @@ var session = require('express-session');
 var cookieParser = require('cookie-parser');
 var debug = require('debug')('keystone:core:initExpressSession');
 
-module.exports = function initExpressSession () {
+module.exports = function initExpressSession (mongoose) {
 
 	if (this.expressSession) return this;
 
@@ -55,7 +55,7 @@ module.exports = function initExpressSession () {
 				debug('using connect-mongo session store');
 				_.defaults(sessionStoreOptions, {
 					collection: 'app_sessions',
-					url: this.get('mongo'),
+					mongooseConnection: mongoose.connection,
 				});
 				break;
 

--- a/server/createApp.js
+++ b/server/createApp.js
@@ -18,7 +18,7 @@ module.exports = function createApp (keystone, express) {
 	var app = keystone.app;
 
 	keystone.initDatabase();
-	keystone.initExpressSession();
+	keystone.initExpressSession(keystone.mongoose);
 
 	require('./initTrustProxy')(keystone, app);
 	require('./initViewEngine')(keystone, app);


### PR DESCRIPTION
This patch reuses the mongoose as the storage driver of connect-mongo
and avoid future operation issues.
See keystone/kestone-classic#3172 for reference.