### PR TITLE
ci: add circleci to build and publish the package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,60 @@
+version: 2.1
+executors:
+  node-executor:
+    docker:
+      - image: circleci/node:10.15
+    working_directory: ~/keystone
+
+commands:
+  set-npm-auth:
+    description: "Set NPM authentication"
+    steps:
+      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc
+
+  install-deps:
+    description: "Install build dependencies"
+    steps:
+      - restore_cache:
+          keys:
+            - v1-dependencies-build-{{ checksum "yarn.lock" }}
+      - run: yarn install --forzen-lockfile
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-build-{{ checksum "yarn.lcok" }}
+
+jobs:
+  build:
+     executor: node-executor
+     steps:
+       - checkout
+       - install-deps
+       - run: yarn build
+       - persist_to_workspace:
+          root: ~/keystone
+          paths:
+            - ./*
+  publish:
+    executor: node-executor
+    working_directory: ~/keystone
+    steps:
+      - attach_workspace:
+          at: .
+      - set-npm-auth
+      - run: npm publish
+
+workflows:
+  version: 2.1
+  build-and-publish:
+    jobs:
+      - build
+      - publish:
+          context: twreporter
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+(-rc\.\d+)?$/
+            branches:
+              only:
+                - master

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ![KeystoneJS](http://keystonejs.com/images/logo.svg)
 ===================================
-
-[![Build Status](https://travis-ci.org/keystonejs/keystone.svg?branch=master)](https://travis-ci.org/keystonejs/keystone)
+[![CircleCI](https://circleci.com/gh/twreporter/keystone/tree/master.svg?style=shield)](https://circleci.com/gh/twreporter/keystone/tree/master)
 
 [KeystoneJS](http://keystonejs.com) is a powerful Node.js content management system and web app framework built on [express](http://expressjs.com) and [mongoose](http://mongoosejs.com). Keystone makes it easy to create sophisticated web sites and apps, and comes with a beautiful auto-generated Admin UI.
 
@@ -168,7 +167,7 @@ Keystone's field types include:
 *	[Text](http://keystonejs.com/docs/database/#fieldtypes-text)
 *	[Textarea](http://keystonejs.com/docs/database/#fieldtypes-textarea)
 *	[Url](http://keystonejs.com/docs/database/#fieldtypes-url)
-*	[Azure File](http://keystonejs.com/docs/database/#fieldtypes-azurefile)  
+*	[Azure File](http://keystonejs.com/docs/database/#fieldtypes-azurefile)
 *	[CloudinaryImage](http://keystonejs.com/docs/database/#fieldtypes-cloudinaryimage)
 *	[CloudinaryImages](http://keystonejs.com/docs/database/#fieldtypes-cloudinaryimages)
 *	[Embedly](http://keystonejs.com/docs/database/#fieldtypes-embedly)


### PR DESCRIPTION
This patch adds the circleci configuration to build and publish the
package. To publish the package, a developer should tag the target
commit with defined syntax.(e.g. v0.9.1 or v0.9.1-rc.0)