### PR TITLE
ci: fix tag trigger build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,10 @@ workflows:
   version: 2.1
   build-and-publish:
     jobs:
-      - build
+      - build:
+        filters:
+          tags:
+            only: /^v\d+\.\d+\.\d+(-rc\.\d+)?$/
       - publish:
           context: twreporter
           requires:


### PR DESCRIPTION
This patch fixes the trigger of tag which should be specified
explicitly.
Ref:
https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag