### PR TITLE
ci: fix the identation of filters field

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,9 @@ workflows:
   build-and-publish:
     jobs:
       - build:
-        filters:
-          tags:
-            only: /^v\d+\.\d+\.\d+(-rc\.\d+)?$/
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+(-rc\.\d+)?$/
       - publish:
           context: twreporter
           requires:


### PR DESCRIPTION
This patch fixes the identation of filters field which should be under
the build job.