### PR TITLE
fix: expire cookie session

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -2,6 +2,7 @@ var crypto = require('crypto');
 var keystone = require('../');
 var scmp = require('scmp');
 var utils = require('keystone-utils');
+var _ = require('lodash');
 
 /**
  * Creates a hash of str with Keystone's cookie secret.
@@ -49,11 +50,19 @@ function signinWithUser (user, req, res, onSuccess) {
 		req.user = user;
 		req.session.userId = user.id;
 		// set user name to cookie for keystone-plugin (chatroom)
-		res.cookie('keystone.user_name', user.name)
+		res.cookie('keystone.user_name', user.name);
 		// if the user has a password set, store a persistence cookie to resume sessions
 		if (keystone.get('cookie signin') && user.password) {
 			var userToken = user.id + ':' + hash(user.password);
-			res.cookie('keystone.uid', userToken, { signed: true, httpOnly: true });
+			var cookieOpts = _.defaults({}, keystone.get('cookie signin options'), {
+				signed: true,
+				httpOnly: true,
+				maxAge: 14 * 24 * 60 * 60 * 1000,
+			});
+			if (req.session.cookie) {
+				req.session.cookie.maxAge = cookieOpts.maxAge;
+			}
+			res.cookie('keystone.uid', userToken, cookieOpts);
 		}
 		onSuccess(user);
 	});
@@ -143,7 +152,12 @@ exports.signout = function (req, res, next) {
 		if (err) {
 			console.log("An error occurred in signout 'pre' middleware", err);
 		}
-		res.clearCookie('keystone.uid');
+		var cookieOpts = _.defaults({}, keystone.get('cookie signin options'), {
+			signed: true,
+			httpOnly: true,
+		});
+		cookieOpts.maxAge = 0;
+		res.clearCookie('keystone.uid', cookieOpts);
 		req.user = null;
 		req.session.regenerate(function (err) {
 			if (err) {
@@ -177,13 +191,14 @@ exports.persist = function (req, res, next) {
 		process.exit(1);
 	}
 	if (keystone.get('cookie signin') && !req.session.userId && req.signedCookies['keystone.uid'] && req.signedCookies['keystone.uid'].indexOf(':') > 0) {
-		exports.signin(req.signedCookies['keystone.uid'], req, res, function () {
-			next();
-		}, function (err) {
-			res.clearCookie('keystone.uid');
-			req.user = null;
-			next();
+		var cookieOpts = _.defaults({}, keystone.get('cookie signin options'), {
+			signed: true,
+			httpOnly: true,
 		});
+		cookieOpts.maxAge = 0;
+		res.clearCookie('keystone.uid', cookieOpts);
+		req.user = null;
+		next();
 	} else if (req.session.userId) {
 		User.model.findById(req.session.userId).exec(function (err, user) {
 			if (err) return next(err);


### PR DESCRIPTION
This patch sets the maxAge of the cookie session and force the expired
user session to signin again. Also, adds the `cookie signin options` for
configuration of the cookie.