### PR TITLE
fix: editor flashes when typing Chinese

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,12 @@
   "rules": {
     "indent": ["error", 2, {"SwitchCase": 1}],
     "react/jsx-indent": ["error", 2],
-    "react/jsx-indent-props": [2, 2]
+    "react/jsx-indent-props": [2, 2],
+    "space-before-function-paren": ["error", {
+      "anonymous": "never",
+      "named": "never",
+      "asyncArrow": "always"
+    }]
   },
   "globals": {
     "_": true,

--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,11 @@
   "extends": [
      "keystone"
   ],
+  "rules": {
+    "indent": ["error", 2, {"SwitchCase": 1}],
+    "react/jsx-indent": ["error", 2],
+    "react/jsx-indent-props": [2, 2]
+  },
   "globals": {
     "_": true,
     "$": true,

--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -1,5 +1,20 @@
-import { BlockMapBuilder, Editor, EditorState, KeyBindingUtil, Modifier, RichUtils, convertFromHTML, convertFromRaw, convertToRaw, getDefaultKeyBinding } from '@twreporter/draft-js';
-import { BlockStyleButtons, EntityButtons, InlineStyleButtons } from './editor/editor-buttons';
+import {
+	BlockMapBuilder,
+	Editor,
+	EditorState,
+	KeyBindingUtil,
+	Modifier,
+	RichUtils,
+	convertFromHTML,
+	convertFromRaw,
+	convertToRaw,
+	getDefaultKeyBinding,
+} from '@twreporter/draft-js';
+import {
+	BlockStyleButtons,
+	EntityButtons,
+	InlineStyleButtons,
+} from './editor/editor-buttons';
 import { Button, FormInput } from 'elemental';
 import ENTITY from './editor/entities';
 import AtomicBlockSwitcher from './editor/base/atomic-block-switcher';
@@ -13,12 +28,15 @@ const { isCtrlKeyCommand } = KeyBindingUtil;
 
 let lastId = 0;
 
-function getId () {
+function getId() {
 	return 'keystone-html-' + lastId++;
 }
 
-function refreshEditorState (editorState) {
-	return EditorState.forceSelection(editorState, editorState.getCurrentContent().getSelectionAfter());
+function refreshEditorState(editorState) {
+	return EditorState.forceSelection(
+		editorState,
+		editorState.getCurrentContent().getSelectionAfter()
+	);
 }
 
 // workaround here for using @twreporter/react-article-components pkg
@@ -31,8 +49,7 @@ if (window) {
 module.exports = Field.create({
 	displayName: 'HtmlField',
 
-	getInitialState () {
-
+	getInitialState() {
 		// convert saved editor content into the editor state
 		let editorState;
 		try {
@@ -45,8 +62,7 @@ module.exports = Field.create({
 				// create empty draft object
 				editorState = EditorState.createEmpty(decorator);
 			}
-		}
-		catch (error) {
+		} catch (error) {
 			// create empty EditorState
 			editorState = EditorState.createEmpty(decorator);
 		}
@@ -58,14 +74,13 @@ module.exports = Field.create({
 		};
 	},
 
-
-	_convertToApiData (editorState) {
+	_convertToApiData(editorState) {
 		const content = convertToRaw(editorState.getCurrentContent());
 		const apiData = DraftConverter.convertToApiData(content);
 		return apiData.toJS();
 	},
 
-	onChange (editorState) {
+	onChange(editorState) {
 		const content = convertToRaw(editorState.getCurrentContent());
 		const cHtml = DraftConverter.convertToHtml(content);
 		const apiData = DraftConverter.convertToApiData(content);
@@ -89,11 +104,11 @@ module.exports = Field.create({
 		}
 	},
 
-	focus () {
+	focus() {
 		this.refs.editor.focus();
 	},
 
-	handleKeyCommand (command) {
+	handleKeyCommand(command) {
 		const { editorState } = this.state;
 		let newState;
 		switch (command) {
@@ -110,7 +125,7 @@ module.exports = Field.create({
 		return false;
 	},
 
-	keyBindingFn (e) {
+	keyBindingFn(e) {
 		if (e.keyCode === 13 /* `enter` key */) {
 			if (isCtrlKeyCommand(e) || e.shiftKey) {
 				return 'insert-soft-newline';
@@ -119,26 +134,18 @@ module.exports = Field.create({
 		return getDefaultKeyBinding(e);
 	},
 
-	toggleBlockType (blockType) {
+	toggleBlockType(blockType) {
 		let editorState = this.state.editorState;
+		this.onChange(RichUtils.toggleBlockType(editorState, blockType));
+	},
+
+	toggleInlineStyle(inlineStyle) {
 		this.onChange(
-			RichUtils.toggleBlockType(
-				editorState,
-				blockType
-			)
+			RichUtils.toggleInlineStyle(this.state.editorState, inlineStyle)
 		);
 	},
 
-	toggleInlineStyle (inlineStyle) {
-		this.onChange(
-			RichUtils.toggleInlineStyle(
-				this.state.editorState,
-				inlineStyle
-			)
-		);
-	},
-
-	_toggleTextWithEntity (entityKey, text) {
+	_toggleTextWithEntity(entityKey, text) {
 		const { editorState } = this.state;
 		const selection = editorState.getSelection();
 		let contentState = editorState.getCurrentContent();
@@ -157,16 +164,24 @@ module.exports = Field.create({
 			null,
 			entityKey
 		);
-		const _editorState = EditorState.push(editorState, contentState, editorState.getLastChangeType());
+		const _editorState = EditorState.push(
+			editorState,
+			contentState,
+			editorState.getLastChangeType()
+		);
 		this.onChange(_editorState);
 	},
 
-	_toggleAtomicBlock (entity, value) {
-		const _editorState = BlockModifier.insertAtomicBlock(this.state.editorState, entity, value);
+	_toggleAtomicBlock(entity, value) {
+		const _editorState = BlockModifier.insertAtomicBlock(
+			this.state.editorState,
+			entity,
+			value
+		);
 		this.onChange(_editorState);
 	},
 
-	_toggleAudio (entity, value) {
+	_toggleAudio(entity, value) {
 		const audio = Array.isArray(value) ? value[0] : null;
 		if (!audio) {
 			return;
@@ -174,14 +189,18 @@ module.exports = Field.create({
 		this._toggleAtomicBlock(entity, audio);
 	},
 
-	_toggleInlineEntity (entity, value) {
+	_toggleInlineEntity(entity, value) {
 		let contentState = this.state.editorState.getCurrentContent();
-    const contentStateWithEntity = contentState.createEntity(entity, 'IMMUTABLE', value);
-    const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
+		const contentStateWithEntity = contentState.createEntity(
+			entity,
+			'IMMUTABLE',
+			value
+		);
+		const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
 		this._toggleTextWithEntity(entityKey, _.get(value, 'text'));
 	},
 
-	_toggleImage (entity, value) {
+	_toggleImage(entity, value) {
 		const image = Array.isArray(value) ? value[0] : null;
 		if (!image) {
 			return;
@@ -189,7 +208,7 @@ module.exports = Field.create({
 		this._toggleAtomicBlock(entity, image);
 	},
 
-	_toggleImageDiff (entity, value) {
+	_toggleImageDiff(entity, value) {
 		const images = Array.isArray(value) && value.length === 2 ? value : null;
 		if (!images) {
 			return;
@@ -197,7 +216,7 @@ module.exports = Field.create({
 		this._toggleAtomicBlock(entity, images);
 	},
 
-	_toggleSlideshow (entity, value) {
+	_toggleSlideshow(entity, value) {
 		const images = Array.isArray(value) && value.length > 0 ? value : null;
 		if (!images) {
 			return;
@@ -205,8 +224,7 @@ module.exports = Field.create({
 		this._toggleAtomicBlock(entity, images);
 	},
 
-
-	toggleEntity (entity, value) {
+	toggleEntity(entity, value) {
 		switch (entity) {
 			case ENTITY.AUDIO.type:
 				return this._toggleAudio(entity, value);
@@ -230,13 +248,17 @@ module.exports = Field.create({
 		}
 	},
 
-	_blockRenderer (block) {
+	_blockRenderer(block) {
 		if (block.getType() === 'atomic') {
 			return {
 				component: AtomicBlockSwitcher,
 				props: {
 					onFinishEdit: (blockKey, valueChanged) => {
-						const _editorState = BlockModifier.handleAtomicEdit(this.state.editorState, blockKey, valueChanged);
+						const _editorState = BlockModifier.handleAtomicEdit(
+							this.state.editorState,
+							blockKey,
+							valueChanged
+						);
 
 						// workaround here.
 						// use refreshEditorState to make the Editor rerender
@@ -248,21 +270,28 @@ module.exports = Field.create({
 					data: this._convertToApiData(this.state.editorState),
 					// render desktop layout when editor is enlarged,
 					// otherwise render mobile layout
-          device: this.state.isEnlarged ? 'desktop' : 'mobile',
+					device: this.state.isEnlarged ? 'desktop' : 'mobile',
 				},
 			};
 		}
 		return null;
 	},
 
-	enlargeEditor () {
+	enlargeEditor() {
 		// also set editorState to force editor to re-render
-		this.setState({ isEnlarged: !this.state.isEnlarged, editorState: refreshEditorState(this.state.editorState) });
+		this.setState({
+			isEnlarged: !this.state.isEnlarged,
+			editorState: refreshEditorState(this.state.editorState),
+		});
 	},
 
-	handlePastedText (text, html) {
-		function insertFragment (editorState, fragment) {
-			let newContent = Modifier.replaceWithFragment(editorState.getCurrentContent(), editorState.getSelection(), fragment);
+	handlePastedText(text, html) {
+		function insertFragment(editorState, fragment) {
+			let newContent = Modifier.replaceWithFragment(
+				editorState.getCurrentContent(),
+				editorState.getSelection(),
+				fragment
+			);
 			return EditorState.push(editorState, newContent, 'insert-fragment');
 		}
 
@@ -274,13 +303,15 @@ module.exports = Field.create({
 			// currently, just handle p, h1, h2, ..., h6 tag
 			// NOTE: I don't know why header style can not be parsed into ContentBlock,
 			// so I replace it by div temporarily
-			html = html.replace(/<p|<h1|<h2|<h3|<h4|<h5|<h6/g, '<div').replace(/<\/p|<\/h1|<\/h2|<\/h3|<\/h4|<\/h5|<\/h6/g, '</div');
+			html = html
+				.replace(/<p|<h1|<h2|<h3|<h4|<h5|<h6/g, '<div')
+				.replace(/<\/p|<\/h1|<\/h2|<\/h3|<\/h4|<\/h5|<\/h6/g, '</div');
 
 			let editorState = this.state.editorState;
-      const htmlFragment = convertFromHTML(html);
-      if (htmlFragment) {
-        const { contentBlocks, entityMap } = htmlFragment;
-        const htmlMap = BlockMapBuilder.createFromArray(contentBlocks);
+			const htmlFragment = convertFromHTML(html);
+			if (htmlFragment) {
+				const { contentBlocks, entityMap } = htmlFragment;
+				const htmlMap = BlockMapBuilder.createFromArray(contentBlocks);
 				this.onChange(insertFragment(editorState, htmlMap));
 				// prevent the default paste behavior.
 				return true;
@@ -290,7 +321,7 @@ module.exports = Field.create({
 		return false;
 	},
 
-	renderField () {
+	renderField() {
 		const { editorState } = this.state;
 		const useSpellCheck = true;
 
@@ -327,13 +358,21 @@ module.exports = Field.create({
 							<InlineStyleButtons
 								buttons={INLINE_STYLES}
 								editorState={editorState}
-								onToggle={this.toggleInlineStyle} />
+								onToggle={this.toggleInlineStyle}
+							/>
 							<EntityButtons
 								entities={Object.keys(ENTITY)}
 								editorState={editorState}
 								onToggle={this.toggleEntity}
 							/>
-							<Button type={'hollow-primary DraftEditor-expandButton' + expandBtnClass} onClick={this.enlargeEditor}><i className={'fa ' + expandIcon} aria-hidden="true"></i></Button>
+							<Button
+								type={
+									'hollow-primary DraftEditor-expandButton' + expandBtnClass
+								}
+								onClick={this.enlargeEditor}
+							>
+								<i className={'fa ' + expandIcon} aria-hidden="true"></i>
+							</Button>
 						</div>
 					</div>
 					<div className={className + expandBtnClass} onClick={this.focus}>
@@ -350,15 +389,21 @@ module.exports = Field.create({
 							ref="editor"
 							spellCheck={useSpellCheck}
 						/>
-						<FormInput type="hidden" name={this.props.path} value={this.state.valueStr} />
+						<FormInput
+							type="hidden"
+							name={this.props.path}
+							value={this.state.valueStr}
+						/>
 					</div>
 				</div>
 			</div>
 		);
 	},
 
-	renderValue () {
-		return <FormInput multiline noedit value={JSON.stringify(this.props.value)} />;
+	renderValue() {
+		return (
+			<FormInput multiline noedit value={JSON.stringify(this.props.value)} />
+		);
 	},
 });
 
@@ -371,7 +416,6 @@ const styleMap = {
 		padding: 2,
 	},
 };
-
 
 // block settings
 const BLOCK_TYPES = [
@@ -390,4 +434,3 @@ var INLINE_STYLES = [
 	{ label: 'Underline', style: 'UNDERLINE', icon: 'fa-underline', text: '' },
 	{ label: 'Monospace', style: 'CODE', icon: 'fa-terminal', text: '' },
 ];
-

--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -277,9 +277,10 @@ module.exports = Field.create({
 			html = html.replace(/<p|<h1|<h2|<h3|<h4|<h5|<h6/g, '<div').replace(/<\/p|<\/h1|<\/h2|<\/h3|<\/h4|<\/h5|<\/h6/g, '</div');
 
 			let editorState = this.state.editorState;
-			var htmlFragment = convertFromHTML(html);
+      const htmlFragment = convertFromHTML(html);
       if (htmlFragment) {
-				var htmlMap = BlockMapBuilder.createFromArray(htmlFragment);
+        const { contentBlocks, entityMap } = htmlFragment;
+        const htmlMap = BlockMapBuilder.createFromArray(contentBlocks);
 				this.onChange(insertFragment(editorState, htmlMap));
 				// prevent the default paste behavior.
 				return true;

--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -1,4 +1,4 @@
-import { BlockMapBuilder, Editor, EditorState, KeyBindingUtil, Modifier, Entity, RichUtils, convertFromHTML, convertFromRaw, convertToRaw, getDefaultKeyBinding } from 'draft-js';
+import { BlockMapBuilder, Editor, EditorState, KeyBindingUtil, Modifier, RichUtils, convertFromHTML, convertFromRaw, convertToRaw, getDefaultKeyBinding } from 'draft-js';
 import { BlockStyleButtons, EntityButtons, InlineStyleButtons } from './editor/editor-buttons';
 import { Button, FormInput } from 'elemental';
 import ENTITY from './editor/entities';
@@ -175,7 +175,9 @@ module.exports = Field.create({
 	},
 
 	_toggleInlineEntity (entity, value) {
-		const entityKey = Entity.create(entity, 'IMMUTABLE', value);
+		let contentState = this.state.editorState.getCurrentContent();
+    const contentStateWithEntity = contentState.createEntity(entity, 'IMMUTABLE', value);
+    const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
 		this._toggleTextWithEntity(entityKey, _.get(value, 'text'));
 	},
 
@@ -246,7 +248,7 @@ module.exports = Field.create({
 					data: this._convertToApiData(this.state.editorState),
 					// render desktop layout when editor is enlarged,
 					// otherwise render mobile layout
-					device: this.state.isEnlarged ? 'desktop' : 'mobile',
+          device: this.state.isEnlarged ? 'desktop' : 'mobile',
 				},
 			};
 		}
@@ -276,7 +278,7 @@ module.exports = Field.create({
 
 			let editorState = this.state.editorState;
 			var htmlFragment = convertFromHTML(html);
-			if (htmlFragment) {
+      if (htmlFragment) {
 				var htmlMap = BlockMapBuilder.createFromArray(htmlFragment);
 				this.onChange(insertFragment(editorState, htmlMap));
 				// prevent the default paste behavior.

--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -1,4 +1,4 @@
-import { BlockMapBuilder, Editor, EditorState, KeyBindingUtil, Modifier, RichUtils, convertFromHTML, convertFromRaw, convertToRaw, getDefaultKeyBinding } from 'draft-js';
+import { BlockMapBuilder, Editor, EditorState, KeyBindingUtil, Modifier, RichUtils, convertFromHTML, convertFromRaw, convertToRaw, getDefaultKeyBinding } from '@twreporter/draft-js';
 import { BlockStyleButtons, EntityButtons, InlineStyleButtons } from './editor/editor-buttons';
 import { Button, FormInput } from 'elemental';
 import ENTITY from './editor/entities';

--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -1,19 +1,19 @@
 import {
-	BlockMapBuilder,
-	Editor,
-	EditorState,
-	KeyBindingUtil,
-	Modifier,
-	RichUtils,
-	convertFromHTML,
-	convertFromRaw,
-	convertToRaw,
-	getDefaultKeyBinding,
+  BlockMapBuilder,
+  Editor,
+  EditorState,
+  KeyBindingUtil,
+  Modifier,
+  RichUtils,
+  convertFromHTML,
+  convertFromRaw,
+  convertToRaw,
+  getDefaultKeyBinding,
 } from '@twreporter/draft-js';
 import {
-	BlockStyleButtons,
-	EntityButtons,
-	InlineStyleButtons,
+  BlockStyleButtons,
+  EntityButtons,
+  InlineStyleButtons,
 } from './editor/editor-buttons';
 import { Button, FormInput } from 'elemental';
 import ENTITY from './editor/entities';
@@ -29,408 +29,408 @@ const { isCtrlKeyCommand } = KeyBindingUtil;
 let lastId = 0;
 
 function getId() {
-	return 'keystone-html-' + lastId++;
+  return 'keystone-html-' + lastId++;
 }
 
 function refreshEditorState(editorState) {
-	return EditorState.forceSelection(
-		editorState,
-		editorState.getCurrentContent().getSelectionAfter()
-	);
+  return EditorState.forceSelection(
+    editorState,
+    editorState.getCurrentContent().getSelectionAfter()
+  );
 }
 
 // workaround here for using @twreporter/react-article-components pkg
 if (window) {
-	// set __DEVELOPMENT__ as true to get image and audio from google stroage
-	window.__DEVELOPMENT__ = true;
+  // set __DEVELOPMENT__ as true to get image and audio from google stroage
+  window.__DEVELOPMENT__ = true;
 }
 
 // class HtmlField extends React.Component {
 module.exports = Field.create({
-	displayName: 'HtmlField',
+  displayName: 'HtmlField',
 
-	getInitialState() {
-		// convert saved editor content into the editor state
-		let editorState;
-		try {
-			const { draft, html } = this.props.value;
-			if (draft && html !== '') {
-				// create an EditorState from the raw Draft data
-				let contentState = convertFromRaw(draft);
-				editorState = EditorState.createWithContent(contentState, decorator);
-			} else {
-				// create empty draft object
-				editorState = EditorState.createEmpty(decorator);
-			}
-		} catch (error) {
-			// create empty EditorState
-			editorState = EditorState.createEmpty(decorator);
-		}
+  getInitialState() {
+    // convert saved editor content into the editor state
+    let editorState;
+    try {
+      const { draft, html } = this.props.value;
+      if (draft && html !== '') {
+        // create an EditorState from the raw Draft data
+        let contentState = convertFromRaw(draft);
+        editorState = EditorState.createWithContent(contentState, decorator);
+      } else {
+        // create empty draft object
+        editorState = EditorState.createEmpty(decorator);
+      }
+    } catch (error) {
+      // create empty EditorState
+      editorState = EditorState.createEmpty(decorator);
+    }
 
-		return {
-			editorState: editorState,
-			id: getId(),
-			valueStr: JSON.stringify(this.props.value),
-		};
-	},
+    return {
+      editorState: editorState,
+      id: getId(),
+      valueStr: JSON.stringify(this.props.value),
+    };
+  },
 
-	_convertToApiData(editorState) {
-		const content = convertToRaw(editorState.getCurrentContent());
-		const apiData = DraftConverter.convertToApiData(content);
-		return apiData.toJS();
-	},
+  _convertToApiData(editorState) {
+    const content = convertToRaw(editorState.getCurrentContent());
+    const apiData = DraftConverter.convertToApiData(content);
+    return apiData.toJS();
+  },
 
-	onChange(editorState) {
-		const content = convertToRaw(editorState.getCurrentContent());
-		const cHtml = DraftConverter.convertToHtml(content);
-		const apiData = DraftConverter.convertToApiData(content);
+  onChange(editorState) {
+    const content = convertToRaw(editorState.getCurrentContent());
+    const cHtml = DraftConverter.convertToHtml(content);
+    const apiData = DraftConverter.convertToApiData(content);
 
-		const valueStr = JSON.stringify({
-			draft: content,
-			html: cHtml,
-			apiData,
-		});
+    const valueStr = JSON.stringify({
+      draft: content,
+      html: cHtml,
+      apiData,
+    });
 
-		// update value if the content has been changed
-		if (valueStr !== this.state.valueStr) {
-			this.setState({
-				valueStr,
-				editorState,
-			});
-		} else {
-			this.setState({
-				editorState,
-			});
-		}
-	},
+    // update value if the content has been changed
+    if (valueStr !== this.state.valueStr) {
+      this.setState({
+        valueStr,
+        editorState,
+      });
+    } else {
+      this.setState({
+        editorState,
+      });
+    }
+  },
 
-	focus() {
-		this.refs.editor.focus();
-	},
+  focus() {
+    this.refs.editor.focus();
+  },
 
-	handleKeyCommand(command) {
-		const { editorState } = this.state;
-		let newState;
-		switch (command) {
-			case 'insert-soft-newline':
-				newState = RichUtils.insertSoftNewline(editorState);
-				break;
-			default:
-				newState = RichUtils.handleKeyCommand(editorState, command);
-		}
-		if (newState) {
-			this.onChange(newState);
-			return true;
-		}
-		return false;
-	},
+  handleKeyCommand(command) {
+    const { editorState } = this.state;
+    let newState;
+    switch (command) {
+      case 'insert-soft-newline':
+        newState = RichUtils.insertSoftNewline(editorState);
+        break;
+      default:
+        newState = RichUtils.handleKeyCommand(editorState, command);
+    }
+    if (newState) {
+      this.onChange(newState);
+      return true;
+    }
+    return false;
+  },
 
-	keyBindingFn(e) {
-		if (e.keyCode === 13 /* `enter` key */) {
-			if (isCtrlKeyCommand(e) || e.shiftKey) {
-				return 'insert-soft-newline';
-			}
-		}
-		return getDefaultKeyBinding(e);
-	},
+  keyBindingFn(e) {
+    if (e.keyCode === 13 /* `enter` key */) {
+      if (isCtrlKeyCommand(e) || e.shiftKey) {
+        return 'insert-soft-newline';
+      }
+    }
+    return getDefaultKeyBinding(e);
+  },
 
-	toggleBlockType(blockType) {
-		let editorState = this.state.editorState;
-		this.onChange(RichUtils.toggleBlockType(editorState, blockType));
-	},
+  toggleBlockType(blockType) {
+    let editorState = this.state.editorState;
+    this.onChange(RichUtils.toggleBlockType(editorState, blockType));
+  },
 
-	toggleInlineStyle(inlineStyle) {
-		this.onChange(
-			RichUtils.toggleInlineStyle(this.state.editorState, inlineStyle)
-		);
-	},
+  toggleInlineStyle(inlineStyle) {
+    this.onChange(
+      RichUtils.toggleInlineStyle(this.state.editorState, inlineStyle)
+    );
+  },
 
-	_toggleTextWithEntity(entityKey, text) {
-		const { editorState } = this.state;
-		const selection = editorState.getSelection();
-		let contentState = editorState.getCurrentContent();
+  _toggleTextWithEntity(entityKey, text) {
+    const { editorState } = this.state;
+    const selection = editorState.getSelection();
+    let contentState = editorState.getCurrentContent();
 
-		if (selection.isCollapsed()) {
-			contentState = Modifier.removeRange(
-				editorState.getCurrentContent(),
-				selection,
-				'backward'
-			);
-		}
-		contentState = Modifier.replaceText(
-			contentState,
-			selection,
-			text,
-			null,
-			entityKey
-		);
-		const _editorState = EditorState.push(
-			editorState,
-			contentState,
-			editorState.getLastChangeType()
-		);
-		this.onChange(_editorState);
-	},
+    if (selection.isCollapsed()) {
+      contentState = Modifier.removeRange(
+        editorState.getCurrentContent(),
+        selection,
+        'backward'
+      );
+    }
+    contentState = Modifier.replaceText(
+      contentState,
+      selection,
+      text,
+      null,
+      entityKey
+    );
+    const _editorState = EditorState.push(
+      editorState,
+      contentState,
+      editorState.getLastChangeType()
+    );
+    this.onChange(_editorState);
+  },
 
-	_toggleAtomicBlock(entity, value) {
-		const _editorState = BlockModifier.insertAtomicBlock(
-			this.state.editorState,
-			entity,
-			value
-		);
-		this.onChange(_editorState);
-	},
+  _toggleAtomicBlock(entity, value) {
+    const _editorState = BlockModifier.insertAtomicBlock(
+      this.state.editorState,
+      entity,
+      value
+    );
+    this.onChange(_editorState);
+  },
 
-	_toggleAudio(entity, value) {
-		const audio = Array.isArray(value) ? value[0] : null;
-		if (!audio) {
-			return;
-		}
-		this._toggleAtomicBlock(entity, audio);
-	},
+  _toggleAudio(entity, value) {
+    const audio = Array.isArray(value) ? value[0] : null;
+    if (!audio) {
+      return;
+    }
+    this._toggleAtomicBlock(entity, audio);
+  },
 
-	_toggleInlineEntity(entity, value) {
-		let contentState = this.state.editorState.getCurrentContent();
-		const contentStateWithEntity = contentState.createEntity(
-			entity,
-			'IMMUTABLE',
-			value
-		);
-		const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
-		this._toggleTextWithEntity(entityKey, _.get(value, 'text'));
-	},
+  _toggleInlineEntity(entity, value) {
+    let contentState = this.state.editorState.getCurrentContent();
+    const contentStateWithEntity = contentState.createEntity(
+      entity,
+      'IMMUTABLE',
+      value
+    );
+    const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
+    this._toggleTextWithEntity(entityKey, _.get(value, 'text'));
+  },
 
-	_toggleImage(entity, value) {
-		const image = Array.isArray(value) ? value[0] : null;
-		if (!image) {
-			return;
-		}
-		this._toggleAtomicBlock(entity, image);
-	},
+  _toggleImage(entity, value) {
+    const image = Array.isArray(value) ? value[0] : null;
+    if (!image) {
+      return;
+    }
+    this._toggleAtomicBlock(entity, image);
+  },
 
-	_toggleImageDiff(entity, value) {
-		const images = Array.isArray(value) && value.length === 2 ? value : null;
-		if (!images) {
-			return;
-		}
-		this._toggleAtomicBlock(entity, images);
-	},
+  _toggleImageDiff(entity, value) {
+    const images = Array.isArray(value) && value.length === 2 ? value : null;
+    if (!images) {
+      return;
+    }
+    this._toggleAtomicBlock(entity, images);
+  },
 
-	_toggleSlideshow(entity, value) {
-		const images = Array.isArray(value) && value.length > 0 ? value : null;
-		if (!images) {
-			return;
-		}
-		this._toggleAtomicBlock(entity, images);
-	},
+  _toggleSlideshow(entity, value) {
+    const images = Array.isArray(value) && value.length > 0 ? value : null;
+    if (!images) {
+      return;
+    }
+    this._toggleAtomicBlock(entity, images);
+  },
 
-	toggleEntity(entity, value) {
-		switch (entity) {
-			case ENTITY.AUDIO.type:
-				return this._toggleAudio(entity, value);
-			case ENTITY.BLOCKQUOTE.type:
-			case ENTITY.IMAGELINK.type:
-			case ENTITY.INFOBOX.type:
-			case ENTITY.EMBEDDEDCODE.type:
-			case ENTITY.YOUTUBE.type:
-				return this._toggleAtomicBlock(entity, value);
-			case ENTITY.ANNOTATION.type:
-			case ENTITY.LINK.type:
-				return this._toggleInlineEntity(entity, value);
-			case ENTITY.IMAGE.type:
-				return this._toggleImage(entity, value);
-			case ENTITY.SLIDESHOW.type:
-				return this._toggleSlideshow(entity, value);
-			case ENTITY.IMAGEDIFF.type:
-				return this._toggleImageDiff(entity, value);
-			default:
-				return;
-		}
-	},
+  toggleEntity(entity, value) {
+    switch (entity) {
+      case ENTITY.AUDIO.type:
+        return this._toggleAudio(entity, value);
+      case ENTITY.BLOCKQUOTE.type:
+      case ENTITY.IMAGELINK.type:
+      case ENTITY.INFOBOX.type:
+      case ENTITY.EMBEDDEDCODE.type:
+      case ENTITY.YOUTUBE.type:
+        return this._toggleAtomicBlock(entity, value);
+      case ENTITY.ANNOTATION.type:
+      case ENTITY.LINK.type:
+        return this._toggleInlineEntity(entity, value);
+      case ENTITY.IMAGE.type:
+        return this._toggleImage(entity, value);
+      case ENTITY.SLIDESHOW.type:
+        return this._toggleSlideshow(entity, value);
+      case ENTITY.IMAGEDIFF.type:
+        return this._toggleImageDiff(entity, value);
+      default:
+        return;
+    }
+  },
 
-	_blockRenderer(block) {
-		if (block.getType() === 'atomic') {
-			return {
-				component: AtomicBlockSwitcher,
-				props: {
-					onFinishEdit: (blockKey, valueChanged) => {
-						const _editorState = BlockModifier.handleAtomicEdit(
-							this.state.editorState,
-							blockKey,
-							valueChanged
-						);
+  _blockRenderer(block) {
+    if (block.getType() === 'atomic') {
+      return {
+        component: AtomicBlockSwitcher,
+        props: {
+          onFinishEdit: (blockKey, valueChanged) => {
+            const _editorState = BlockModifier.handleAtomicEdit(
+              this.state.editorState,
+              blockKey,
+              valueChanged
+            );
 
-						// workaround here.
-						// use refreshEditorState to make the Editor rerender
-						this.onChange(refreshEditorState(_editorState));
-					},
-					refreshEditorState: () => {
-						this.onChange(refreshEditorState(this.state.editorState));
-					},
-					data: this._convertToApiData(this.state.editorState),
-					// render desktop layout when editor is enlarged,
-					// otherwise render mobile layout
-					device: this.state.isEnlarged ? 'desktop' : 'mobile',
-				},
-			};
-		}
-		return null;
-	},
+            // workaround here.
+            // use refreshEditorState to make the Editor rerender
+            this.onChange(refreshEditorState(_editorState));
+          },
+          refreshEditorState: () => {
+            this.onChange(refreshEditorState(this.state.editorState));
+          },
+          data: this._convertToApiData(this.state.editorState),
+          // render desktop layout when editor is enlarged,
+          // otherwise render mobile layout
+          device: this.state.isEnlarged ? 'desktop' : 'mobile',
+        },
+      };
+    }
+    return null;
+  },
 
-	enlargeEditor() {
-		// also set editorState to force editor to re-render
-		this.setState({
-			isEnlarged: !this.state.isEnlarged,
-			editorState: refreshEditorState(this.state.editorState),
-		});
-	},
+  enlargeEditor() {
+    // also set editorState to force editor to re-render
+    this.setState({
+      isEnlarged: !this.state.isEnlarged,
+      editorState: refreshEditorState(this.state.editorState),
+    });
+  },
 
-	handlePastedText(text, html) {
-		function insertFragment(editorState, fragment) {
-			let newContent = Modifier.replaceWithFragment(
-				editorState.getCurrentContent(),
-				editorState.getSelection(),
-				fragment
-			);
-			return EditorState.push(editorState, newContent, 'insert-fragment');
-		}
+  handlePastedText(text, html) {
+    function insertFragment(editorState, fragment) {
+      let newContent = Modifier.replaceWithFragment(
+        editorState.getCurrentContent(),
+        editorState.getSelection(),
+        fragment
+      );
+      return EditorState.push(editorState, newContent, 'insert-fragment');
+    }
 
-		if (html) {
-			// remove meta tag
-			html = html.replace(/<meta (.+?)>/g, '');
-			// replace p, h2 by div.
-			// TODO need to find out how many block tags we need to replace
-			// currently, just handle p, h1, h2, ..., h6 tag
-			// NOTE: I don't know why header style can not be parsed into ContentBlock,
-			// so I replace it by div temporarily
-			html = html
-				.replace(/<p|<h1|<h2|<h3|<h4|<h5|<h6/g, '<div')
-				.replace(/<\/p|<\/h1|<\/h2|<\/h3|<\/h4|<\/h5|<\/h6/g, '</div');
+    if (html) {
+      // remove meta tag
+      html = html.replace(/<meta (.+?)>/g, '');
+      // replace p, h2 by div.
+      // TODO need to find out how many block tags we need to replace
+      // currently, just handle p, h1, h2, ..., h6 tag
+      // NOTE: I don't know why header style can not be parsed into ContentBlock,
+      // so I replace it by div temporarily
+      html = html
+        .replace(/<p|<h1|<h2|<h3|<h4|<h5|<h6/g, '<div')
+        .replace(/<\/p|<\/h1|<\/h2|<\/h3|<\/h4|<\/h5|<\/h6/g, '</div');
 
-			let editorState = this.state.editorState;
-			const htmlFragment = convertFromHTML(html);
-			if (htmlFragment) {
-				const { contentBlocks, entityMap } = htmlFragment;
-				const htmlMap = BlockMapBuilder.createFromArray(contentBlocks);
-				this.onChange(insertFragment(editorState, htmlMap));
-				// prevent the default paste behavior.
-				return true;
-			}
-		}
-		// use default paste behavior
-		return false;
-	},
+      let editorState = this.state.editorState;
+      const htmlFragment = convertFromHTML(html);
+      if (htmlFragment) {
+        const { contentBlocks, entityMap } = htmlFragment;
+        const htmlMap = BlockMapBuilder.createFromArray(contentBlocks);
+        this.onChange(insertFragment(editorState, htmlMap));
+        // prevent the default paste behavior.
+        return true;
+      }
+    }
+    // use default paste behavior
+    return false;
+  },
 
-	renderField() {
-		const { editorState } = this.state;
-		const useSpellCheck = true;
+  renderField() {
+    const { editorState } = this.state;
+    const useSpellCheck = true;
 
-		// If the user changes block type before entering any text, we can
-		// either style the placeholder or hide it. Let's just hide it now.
-		let outerClassName = '';
-		let className = 'RichEditor-editor';
-		let expandIcon = 'fa-expand';
-		let expandBtnClass = '';
-		let contentState = editorState.getCurrentContent();
+    // If the user changes block type before entering any text, we can
+    // either style the placeholder or hide it. Let's just hide it now.
+    let outerClassName = '';
+    let className = 'RichEditor-editor';
+    let expandIcon = 'fa-expand';
+    let expandBtnClass = '';
+    let contentState = editorState.getCurrentContent();
 
-		if (!contentState.hasText()) {
-			if (contentState.getBlockMap().first().getType() !== 'unstyled') {
-				className += ' RichEditor-hidePlaceholder';
-			}
-		}
+    if (!contentState.hasText()) {
+      if (contentState.getBlockMap().first().getType() !== 'unstyled') {
+        className += ' RichEditor-hidePlaceholder';
+      }
+    }
 
-		if (this.state.isEnlarged) {
-			outerClassName = 'DraftEditor-fullscreen';
-			expandIcon = 'fa-compress';
-			expandBtnClass = ' expanded';
-		}
+    if (this.state.isEnlarged) {
+      outerClassName = 'DraftEditor-fullscreen';
+      expandIcon = 'fa-compress';
+      expandBtnClass = ' expanded';
+    }
 
-		return (
-			<div className={outerClassName}>
-				<div className="RichEditor-root">
-					<div className={'DraftEditor-controls' + expandBtnClass}>
-						<div className={'DraftEditor-controlsInner' + expandBtnClass}>
-							<BlockStyleButtons
-								buttons={BLOCK_TYPES}
-								editorState={editorState}
-								onToggle={this.toggleBlockType}
-							/>
-							<InlineStyleButtons
-								buttons={INLINE_STYLES}
-								editorState={editorState}
-								onToggle={this.toggleInlineStyle}
-							/>
-							<EntityButtons
-								entities={Object.keys(ENTITY)}
-								editorState={editorState}
-								onToggle={this.toggleEntity}
-							/>
-							<Button
-								type={
-									'hollow-primary DraftEditor-expandButton' + expandBtnClass
-								}
-								onClick={this.enlargeEditor}
-							>
-								<i className={'fa ' + expandIcon} aria-hidden="true"></i>
-							</Button>
-						</div>
-					</div>
-					<div className={className + expandBtnClass} onClick={this.focus}>
-						<Editor
-							blockRendererFn={this._blockRenderer}
-							blockStyleFn={blockStyleFn}
-							customStyleMap={styleMap}
-							editorState={editorState}
-							handleKeyCommand={this.handleKeyCommand}
-							handlePastedText={this.handlePastedText}
-							keyBindingFn={this.keyBindingFn}
-							onChange={this.onChange}
-							placeholder="Enter HTML Here..."
-							ref="editor"
-							spellCheck={useSpellCheck}
-						/>
-						<FormInput
-							type="hidden"
-							name={this.props.path}
-							value={this.state.valueStr}
-						/>
-					</div>
-				</div>
-			</div>
-		);
-	},
+    return (
+      <div className={outerClassName}>
+        <div className="RichEditor-root">
+          <div className={'DraftEditor-controls' + expandBtnClass}>
+            <div className={'DraftEditor-controlsInner' + expandBtnClass}>
+              <BlockStyleButtons
+                buttons={BLOCK_TYPES}
+                editorState={editorState}
+                onToggle={this.toggleBlockType}
+              />
+              <InlineStyleButtons
+                buttons={INLINE_STYLES}
+                editorState={editorState}
+                onToggle={this.toggleInlineStyle}
+              />
+              <EntityButtons
+                entities={Object.keys(ENTITY)}
+                editorState={editorState}
+                onToggle={this.toggleEntity}
+              />
+              <Button
+                type={
+                  'hollow-primary DraftEditor-expandButton' + expandBtnClass
+                }
+                onClick={this.enlargeEditor}
+              >
+                <i className={'fa ' + expandIcon} aria-hidden="true"></i>
+              </Button>
+            </div>
+          </div>
+          <div className={className + expandBtnClass} onClick={this.focus}>
+            <Editor
+              blockRendererFn={this._blockRenderer}
+              blockStyleFn={blockStyleFn}
+              customStyleMap={styleMap}
+              editorState={editorState}
+              handleKeyCommand={this.handleKeyCommand}
+              handlePastedText={this.handlePastedText}
+              keyBindingFn={this.keyBindingFn}
+              onChange={this.onChange}
+              placeholder="Enter HTML Here..."
+              ref="editor"
+              spellCheck={useSpellCheck}
+            />
+            <FormInput
+              type="hidden"
+              name={this.props.path}
+              value={this.state.valueStr}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  },
 
-	renderValue() {
-		return (
-			<FormInput multiline noedit value={JSON.stringify(this.props.value)} />
-		);
-	},
+  renderValue() {
+    return (
+      <FormInput multiline noedit value={JSON.stringify(this.props.value)} />
+    );
+  },
 });
 
 // Custom overrides for "code" style.
 const styleMap = {
-	CODE: {
-		backgroundColor: 'rgba(0, 0, 0, 0.05)',
-		fontFamily: '"Inconsolata", "Menlo", "Consolas", monospace',
-		fontSize: 16,
-		padding: 2,
-	},
+  CODE: {
+    backgroundColor: 'rgba(0, 0, 0, 0.05)',
+    fontFamily: '"Inconsolata", "Menlo", "Consolas", monospace',
+    fontSize: 16,
+    padding: 2,
+  },
 };
 
 // block settings
 const BLOCK_TYPES = [
-	{ label: 'Blockquote', style: 'blockquote', icon: 'fa-quote-left', text: '' },
-	{ label: 'Code Block', style: 'code-block', icon: 'fa-code', text: '' },
-	{ label: 'H1', style: 'header-one', icon: 'fa-header', text: '1' },
-	{ label: 'H2', style: 'header-two', icon: 'fa-header', text: '2' },
-	{ label: 'OL', style: 'ordered-list-item', icon: 'fa-list-ol', text: '' },
-	{ label: 'UL', style: 'unordered-list-item', icon: 'fa-list-ul', text: '' },
+  { label: 'Blockquote', style: 'blockquote', icon: 'fa-quote-left', text: '' },
+  { label: 'Code Block', style: 'code-block', icon: 'fa-code', text: '' },
+  { label: 'H1', style: 'header-one', icon: 'fa-header', text: '1' },
+  { label: 'H2', style: 'header-two', icon: 'fa-header', text: '2' },
+  { label: 'OL', style: 'ordered-list-item', icon: 'fa-list-ol', text: '' },
+  { label: 'UL', style: 'unordered-list-item', icon: 'fa-list-ul', text: '' },
 ];
 
 // inline style settings
 var INLINE_STYLES = [
-	{ label: 'Bold', style: 'BOLD', icon: 'fa-bold', text: '' },
-	{ label: 'Italic', style: 'ITALIC', icon: 'fa-italic', text: '' },
-	{ label: 'Underline', style: 'UNDERLINE', icon: 'fa-underline', text: '' },
-	{ label: 'Monospace', style: 'CODE', icon: 'fa-terminal', text: '' },
+  { label: 'Bold', style: 'BOLD', icon: 'fa-bold', text: '' },
+  { label: 'Italic', style: 'ITALIC', icon: 'fa-italic', text: '' },
+  { label: 'Underline', style: 'UNDERLINE', icon: 'fa-underline', text: '' },
+  { label: 'Monospace', style: 'CODE', icon: 'fa-terminal', text: '' },
 ];

--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -190,7 +190,7 @@ module.exports = Field.create({
   },
 
   _toggleInlineEntity(entity, value) {
-    let contentState = this.state.editorState.getCurrentContent();
+    const contentState = this.state.editorState.getCurrentContent();
     const contentStateWithEntity = contentState.createEntity(
       entity,
       'IMMUTABLE',

--- a/fields/types/html/editor/annotation/annotation-decorator.js
+++ b/fields/types/html/editor/annotation/annotation-decorator.js
@@ -3,7 +3,7 @@ import ENTITY from '../entities';
 import React from 'react';
 import classNames from 'classnames';
 class Annotation extends React.Component {
-	constructor (props) {
+	constructor(props) {
 		super(props);
 		this.state = {
 			isExpanded: false,
@@ -11,28 +11,32 @@ class Annotation extends React.Component {
 		this.handleExpand = this._handleExpand.bind(this);
 	}
 
-	_handleExpand (e) {
+	_handleExpand(e) {
 		e.stopPropagation();
 		this.setState({
 			isExpanded: !this.state.isExpanded,
 		});
 	}
 
-  render () {
-    const { entityKey, contentState } = this.props
-		const { annotation, pureAnnotationText } = contentState.getEntity(entityKey).getData();
+	render() {
+		const { entityKey, contentState } = this.props;
+		const { annotation, pureAnnotationText } = contentState
+			.getEntity(entityKey)
+			.getData();
 		return (
 			<abbr
 				className="annotation"
 				title={pureAnnotationText}
 				style={{ cursor: 'pointer', borderBottom: 0 }}
 			>
-				<span
-					onClick={this.handleExpand}
-					style={{ color: 'red' }}
-				>
+				<span onClick={this.handleExpand} style={{ color: 'red' }}>
 					{this.props.children}
-					<span className={classNames(this.state.isExpanded ? 'up' : '', 'indicator')}/>
+					<span
+						className={classNames(
+							this.state.isExpanded ? 'up' : '',
+							'indicator'
+						)}
+					/>
 				</span>
 				<span
 					className="annotation-html"
@@ -48,22 +52,18 @@ class Annotation extends React.Component {
 			</abbr>
 		);
 	}
-
 }
 
-function findAnnotationEntities (contentBlock, callback, contentState) {
-	contentBlock.findEntityRanges(
-		(character) => {
-			const entityKey = character.getEntity();
-			if (entityKey !== null) {
-				let type = contentState.getEntity(entityKey).getType();
-				type = type && type.toUpperCase();
-				return type === ENTITY.ANNOTATION.type;
-			}
-			return false;
-		},
-		callback
-	);
+function findAnnotationEntities(contentBlock, callback, contentState) {
+	contentBlock.findEntityRanges((character) => {
+		const entityKey = character.getEntity();
+		if (entityKey !== null) {
+			let type = contentState.getEntity(entityKey).getType();
+			type = type && type.toUpperCase();
+			return type === ENTITY.ANNOTATION.type;
+		}
+		return false;
+	}, callback);
 }
 
 export default { strategy: findAnnotationEntities, component: Annotation };

--- a/fields/types/html/editor/annotation/annotation-decorator.js
+++ b/fields/types/html/editor/annotation/annotation-decorator.js
@@ -1,5 +1,4 @@
 'use strict';
-import { Entity } from 'draft-js';
 import ENTITY from '../entities';
 import React from 'react';
 import classNames from 'classnames';
@@ -19,8 +18,9 @@ class Annotation extends React.Component {
 		});
 	}
 
-	render () {
-		const { annotation, pureAnnotationText } = Entity.get(this.props.entityKey).getData();
+  render () {
+    const { entityKey, contentState } = this.props
+		const { annotation, pureAnnotationText } = contentState.getEntity(entityKey).getData();
 		return (
 			<abbr
 				className="annotation"
@@ -51,12 +51,12 @@ class Annotation extends React.Component {
 
 }
 
-function findAnnotationEntities (contentBlock, callback) {
+function findAnnotationEntities (contentBlock, callback, contentState) {
 	contentBlock.findEntityRanges(
 		(character) => {
 			const entityKey = character.getEntity();
 			if (entityKey !== null) {
-				let type = Entity.get(entityKey).getType();
+				let type = contentState.getEntity(entityKey).getType();
 				type = type && type.toUpperCase();
 				return type === ENTITY.ANNOTATION.type;
 			}

--- a/fields/types/html/editor/annotation/annotation-decorator.js
+++ b/fields/types/html/editor/annotation/annotation-decorator.js
@@ -3,67 +3,67 @@ import ENTITY from '../entities';
 import React from 'react';
 import classNames from 'classnames';
 class Annotation extends React.Component {
-	constructor(props) {
-		super(props);
-		this.state = {
-			isExpanded: false,
-		};
-		this.handleExpand = this._handleExpand.bind(this);
-	}
+  constructor(props) {
+    super(props);
+    this.state = {
+      isExpanded: false,
+    };
+    this.handleExpand = this._handleExpand.bind(this);
+  }
 
-	_handleExpand(e) {
-		e.stopPropagation();
-		this.setState({
-			isExpanded: !this.state.isExpanded,
-		});
-	}
+  _handleExpand(e) {
+    e.stopPropagation();
+    this.setState({
+      isExpanded: !this.state.isExpanded,
+    });
+  }
 
-	render() {
-		const { entityKey, contentState } = this.props;
-		const { annotation, pureAnnotationText } = contentState
-			.getEntity(entityKey)
-			.getData();
-		return (
-			<abbr
-				className="annotation"
-				title={pureAnnotationText}
-				style={{ cursor: 'pointer', borderBottom: 0 }}
-			>
-				<span onClick={this.handleExpand} style={{ color: 'red' }}>
-					{this.props.children}
-					<span
-						className={classNames(
-							this.state.isExpanded ? 'up' : '',
-							'indicator'
-						)}
-					/>
-				</span>
-				<span
-					className="annotation-html"
-					dangerouslySetInnerHTML={{ __html: annotation }}
-					style={{
-						display: this.state.isExpanded ? 'block' : 'none',
-						backgroundColor: 'white',
-						padding: '16px',
-						fontSize: '15px',
-						lineHeight: 1.5,
-					}}
-				/>
-			</abbr>
-		);
-	}
+  render() {
+    const { entityKey, contentState } = this.props;
+    const { annotation, pureAnnotationText } = contentState
+      .getEntity(entityKey)
+      .getData();
+    return (
+      <abbr
+        className="annotation"
+        title={pureAnnotationText}
+        style={{ cursor: 'pointer', borderBottom: 0 }}
+      >
+        <span onClick={this.handleExpand} style={{ color: 'red' }}>
+          {this.props.children}
+          <span
+            className={classNames(
+              this.state.isExpanded ? 'up' : '',
+              'indicator'
+            )}
+          />
+        </span>
+        <span
+          className="annotation-html"
+          dangerouslySetInnerHTML={{ __html: annotation }}
+          style={{
+            display: this.state.isExpanded ? 'block' : 'none',
+            backgroundColor: 'white',
+            padding: '16px',
+            fontSize: '15px',
+            lineHeight: 1.5,
+          }}
+        />
+      </abbr>
+    );
+  }
 }
 
 function findAnnotationEntities(contentBlock, callback, contentState) {
-	contentBlock.findEntityRanges((character) => {
-		const entityKey = character.getEntity();
-		if (entityKey !== null) {
-			let type = contentState.getEntity(entityKey).getType();
-			type = type && type.toUpperCase();
-			return type === ENTITY.ANNOTATION.type;
-		}
-		return false;
-	}, callback);
+  contentBlock.findEntityRanges((character) => {
+    const entityKey = character.getEntity();
+    if (entityKey !== null) {
+      let type = contentState.getEntity(entityKey).getType();
+      type = type && type.toUpperCase();
+      return type === ENTITY.ANNOTATION.type;
+    }
+    return false;
+  }, callback);
 }
 
 export default { strategy: findAnnotationEntities, component: Annotation };

--- a/fields/types/html/editor/annotation/annotation-editing-block.js
+++ b/fields/types/html/editor/annotation/annotation-editing-block.js
@@ -6,70 +6,70 @@ import React from 'react';
 import get from 'lodash/get';
 
 const _ = {
-	get,
+  get,
 };
 
 class AnnotationEditingBlock extends EntityEditingBlockMixin(React.Component) {
-	constructor(props) {
-		super(props);
-		this.state.editorState = this._initEditorState(props.draftRawObj);
-	}
+  constructor(props) {
+    super(props);
+    this.state.editorState = this._initEditorState(props.draftRawObj);
+  }
 
-	// overwrite
-	_composeEditingFields(props) {
-		return {
-			text: {
-				type: 'text',
-				value: props.text,
-			},
-			annotation: {
-				type: 'html',
-				value: props.annotation,
-			},
-		};
-	}
+  // overwrite
+  _composeEditingFields(props) {
+    return {
+      text: {
+        type: 'text',
+        value: props.text,
+      },
+      annotation: {
+        type: 'html',
+        value: props.annotation,
+      },
+    };
+  }
 
-	// overwrite
-	_decomposeEditingFields(fields) {
-		let { editorState } = this.state;
-		const content = convertToRaw(editorState.getCurrentContent());
-		const cHtml = DraftConverter.convertToHtml(content, {
-			unstyled: `<div>%content%</div>`,
-		});
-		return {
-			// annotated text
-			text: fields.text.value,
-			annotation: cHtml,
-			pureAnnotationText: _.get(content, ['blocks', 0, 'text'], ''),
-			draftRawObj: content,
-		};
-	}
+  // overwrite
+  _decomposeEditingFields(fields) {
+    let { editorState } = this.state;
+    const content = convertToRaw(editorState.getCurrentContent());
+    const cHtml = DraftConverter.convertToHtml(content, {
+      unstyled: `<div>%content%</div>`,
+    });
+    return {
+      // annotated text
+      text: fields.text.value,
+      annotation: cHtml,
+      pureAnnotationText: _.get(content, ['blocks', 0, 'text'], ''),
+      draftRawObj: content,
+    };
+  }
 
-	// overwrite EntityEditingBlock._handleEditingFieldChange
-	_handleEditingFieldChange(field, e) {
-		if (field === 'annotation') {
-			return;
-		}
-		return super._handleEditingFieldChange(field, e);
-	}
+  // overwrite EntityEditingBlock._handleEditingFieldChange
+  _handleEditingFieldChange(field, e) {
+    if (field === 'annotation') {
+      return;
+    }
+    return super._handleEditingFieldChange(field, e);
+  }
 }
 
 AnnotationEditingBlock.displayName = 'AnnotationEditingBlock';
 
 AnnotationEditingBlock.propTypes = {
-	annotation: React.PropTypes.string,
-	draftRawObj: React.PropTypes.object,
-	isModalOpen: React.PropTypes.bool,
-	onToggle: React.PropTypes.func.isRequired,
-	text: React.PropTypes.string,
-	toggleModal: React.PropTypes.func,
+  annotation: React.PropTypes.string,
+  draftRawObj: React.PropTypes.object,
+  isModalOpen: React.PropTypes.bool,
+  onToggle: React.PropTypes.func.isRequired,
+  text: React.PropTypes.string,
+  toggleModal: React.PropTypes.func,
 };
 
 AnnotationEditingBlock.defaultProps = {
-	annotation: '',
-	draftRawObj: null,
-	isModalOpen: false,
-	text: '',
+  annotation: '',
+  draftRawObj: null,
+  isModalOpen: false,
+  text: '',
 };
 
 export default AnnotationEditingBlock;

--- a/fields/types/html/editor/annotation/annotation-editing-block.js
+++ b/fields/types/html/editor/annotation/annotation-editing-block.js
@@ -6,17 +6,17 @@ import React from 'react';
 import get from 'lodash/get';
 
 const _ = {
-  get,
-}
+	get,
+};
 
 class AnnotationEditingBlock extends EntityEditingBlockMixin(React.Component) {
-	constructor (props) {
+	constructor(props) {
 		super(props);
 		this.state.editorState = this._initEditorState(props.draftRawObj);
 	}
 
 	// overwrite
-	_composeEditingFields (props) {
+	_composeEditingFields(props) {
 		return {
 			text: {
 				type: 'text',
@@ -30,10 +30,12 @@ class AnnotationEditingBlock extends EntityEditingBlockMixin(React.Component) {
 	}
 
 	// overwrite
-	_decomposeEditingFields (fields) {
+	_decomposeEditingFields(fields) {
 		let { editorState } = this.state;
 		const content = convertToRaw(editorState.getCurrentContent());
-		const cHtml = DraftConverter.convertToHtml(content, { unstyled: `<div>%content%</div>` });
+		const cHtml = DraftConverter.convertToHtml(content, {
+			unstyled: `<div>%content%</div>`,
+		});
 		return {
 			// annotated text
 			text: fields.text.value,
@@ -44,13 +46,13 @@ class AnnotationEditingBlock extends EntityEditingBlockMixin(React.Component) {
 	}
 
 	// overwrite EntityEditingBlock._handleEditingFieldChange
-	_handleEditingFieldChange (field, e) {
+	_handleEditingFieldChange(field, e) {
 		if (field === 'annotation') {
 			return;
 		}
 		return super._handleEditingFieldChange(field, e);
 	}
-};
+}
 
 AnnotationEditingBlock.displayName = 'AnnotationEditingBlock';
 

--- a/fields/types/html/editor/annotation/annotation-editing-block.js
+++ b/fields/types/html/editor/annotation/annotation-editing-block.js
@@ -1,5 +1,5 @@
 'use strict';
-import { convertToRaw } from 'draft-js';
+import { convertToRaw } from '@twreporter/draft-js';
 import DraftConverter from '../draft-converter';
 import EntityEditingBlockMixin from '../mixins/entity-editing-block-mixin';
 import React from 'react';

--- a/fields/types/html/editor/base/atomic-block-switcher.js
+++ b/fields/types/html/editor/base/atomic-block-switcher.js
@@ -14,73 +14,87 @@ import Wrapper from './block-wrapper';
 import YoutubeBlock from '../youtube/youtube-block';
 import classNames from 'classnames';
 import get from 'lodash/get';
-import { mobileStyle, tabletMinStyle, tabletMaxStyle } from '../constants/layout-style';
+import {
+	mobileStyle,
+	tabletMinStyle,
+	tabletMaxStyle,
+} from '../constants/layout-style';
 
 const _ = {
-  get,
-}
+	get,
+};
 
 class AtomicBlockSwitcher extends React.Component {
-	constructor (props) {
+	constructor(props) {
 		super(props);
 		this.alignLeft = this._alignLeft.bind(this);
 		this.alignCenter = this._alignCenter.bind(this);
 		this.alignRight = this._alignRight.bind(this);
-        this.alignCenterSmall = this._alignCenterSmall.bind(this);
+		this.alignCenterSmall = this._alignCenterSmall.bind(this);
 	}
 
-	_alignLeft (e) {
+	_alignLeft(e) {
 		e.stopPropagation();
 		this.props.align('left');
 	}
 
-	_alignCenter (e) {
+	_alignCenter(e) {
 		e.stopPropagation();
 		this.props.align('center');
 	}
 
-	_alignRight (e) {
+	_alignRight(e) {
 		e.stopPropagation();
 		this.props.align('right');
 	}
 
-    _alignCenterSmall (e) {
-        e.stopPropagation()
-        this.props.align('center-small')
-    }
+	_alignCenterSmall(e) {
+		e.stopPropagation();
+		this.props.align('center-small');
+	}
 
-  render () {
-    const entityKey = this.props.block.getEntityAt(0);
-		let type = entityKey ? this.props.contentState.getEntity(entityKey).getType() : '';
+	render() {
+		const entityKey = this.props.block.getEntityAt(0);
+		let type = entityKey
+			? this.props.contentState.getEntity(entityKey).getType()
+			: '';
 		// backward compatible. Old data type is lower case
 		type = type && type.toUpperCase();
 
 		const Buttons = (
 			<div style={{ textAlign: 'center' }}>
-				<span className="alignmentButton"
+				<span
+					className="alignmentButton"
 					onClick={this.alignLeft}
 					style={{ marginLeft: '-2.4em' }}
-					role="button" key="left"
+					role="button"
+					key="left"
 				>
 					L
 				</span>
-				<span className="alignmentButton"
+				<span
+					className="alignmentButton"
 					onClick={this.alignCenter}
-					role="button" key="center"
+					role="button"
+					key="center"
 				>
 					C
 				</span>
-				<span className="alignmentButton"
+				<span
+					className="alignmentButton"
 					onClick={this.alignRight}
 					style={{ marginLeft: '0.9em' }}
-					role="button" key="right"
+					role="button"
+					key="right"
 				>
 					R
 				</span>
-				<span className="alignmentButton"
+				<span
+					className="alignmentButton"
 					onClick={this.alignCenterSmall}
 					style={{ marginLeft: '2.6em' }}
-					role="button" key="center-small"
+					role="button"
+					key="center-small"
 				>
 					S
 				</span>
@@ -90,7 +104,6 @@ class AtomicBlockSwitcher extends React.Component {
 		const device = _.get(this.props, ['blockProps', 'device'], 'mobile');
 		let BlockComponent;
 		let style;
-
 
 		switch (type) {
 			case ENTITY.AUDIO.type:
@@ -174,11 +187,8 @@ class AtomicBlockSwitcher extends React.Component {
 
 		return (
 			<div className={classNames('center-block')} style={style}>
-				<BlockComponent
-					{...this.props}
-					device={device}
-				>
-				{device !== 'mobile' ? Buttons : null}
+				<BlockComponent {...this.props} device={device}>
+					{device !== 'mobile' ? Buttons : null}
 				</BlockComponent>
 			</div>
 		);

--- a/fields/types/html/editor/base/atomic-block-switcher.js
+++ b/fields/types/html/editor/base/atomic-block-switcher.js
@@ -15,184 +15,184 @@ import YoutubeBlock from '../youtube/youtube-block';
 import classNames from 'classnames';
 import get from 'lodash/get';
 import {
-	mobileStyle,
-	tabletMinStyle,
-	tabletMaxStyle,
+  mobileStyle,
+  tabletMinStyle,
+  tabletMaxStyle,
 } from '../constants/layout-style';
 
 const _ = {
-	get,
+  get,
 };
 
 class AtomicBlockSwitcher extends React.Component {
-	constructor(props) {
-		super(props);
-		this.alignLeft = this._alignLeft.bind(this);
-		this.alignCenter = this._alignCenter.bind(this);
-		this.alignRight = this._alignRight.bind(this);
-		this.alignCenterSmall = this._alignCenterSmall.bind(this);
-	}
+  constructor(props) {
+    super(props);
+    this.alignLeft = this._alignLeft.bind(this);
+    this.alignCenter = this._alignCenter.bind(this);
+    this.alignRight = this._alignRight.bind(this);
+    this.alignCenterSmall = this._alignCenterSmall.bind(this);
+  }
 
-	_alignLeft(e) {
-		e.stopPropagation();
-		this.props.align('left');
-	}
+  _alignLeft(e) {
+    e.stopPropagation();
+    this.props.align('left');
+  }
 
-	_alignCenter(e) {
-		e.stopPropagation();
-		this.props.align('center');
-	}
+  _alignCenter(e) {
+    e.stopPropagation();
+    this.props.align('center');
+  }
 
-	_alignRight(e) {
-		e.stopPropagation();
-		this.props.align('right');
-	}
+  _alignRight(e) {
+    e.stopPropagation();
+    this.props.align('right');
+  }
 
-	_alignCenterSmall(e) {
-		e.stopPropagation();
-		this.props.align('center-small');
-	}
+  _alignCenterSmall(e) {
+    e.stopPropagation();
+    this.props.align('center-small');
+  }
 
-	render() {
-		const entityKey = this.props.block.getEntityAt(0);
-		let type = entityKey
-			? this.props.contentState.getEntity(entityKey).getType()
-			: '';
-		// backward compatible. Old data type is lower case
-		type = type && type.toUpperCase();
+  render() {
+    const entityKey = this.props.block.getEntityAt(0);
+    let type = entityKey
+      ? this.props.contentState.getEntity(entityKey).getType()
+      : '';
+    // backward compatible. Old data type is lower case
+    type = type && type.toUpperCase();
 
-		const Buttons = (
-			<div style={{ textAlign: 'center' }}>
-				<span
-					className="alignmentButton"
-					onClick={this.alignLeft}
-					style={{ marginLeft: '-2.4em' }}
-					role="button"
-					key="left"
-				>
-					L
-				</span>
-				<span
-					className="alignmentButton"
-					onClick={this.alignCenter}
-					role="button"
-					key="center"
-				>
-					C
-				</span>
-				<span
-					className="alignmentButton"
-					onClick={this.alignRight}
-					style={{ marginLeft: '0.9em' }}
-					role="button"
-					key="right"
-				>
-					R
-				</span>
-				<span
-					className="alignmentButton"
-					onClick={this.alignCenterSmall}
-					style={{ marginLeft: '2.6em' }}
-					role="button"
-					key="center-small"
-				>
-					S
-				</span>
-			</div>
-		);
+    const Buttons = (
+      <div style={{ textAlign: 'center' }}>
+        <span
+          className="alignmentButton"
+          onClick={this.alignLeft}
+          style={{ marginLeft: '-2.4em' }}
+          role="button"
+          key="left"
+        >
+          L
+        </span>
+        <span
+          className="alignmentButton"
+          onClick={this.alignCenter}
+          role="button"
+          key="center"
+        >
+          C
+        </span>
+        <span
+          className="alignmentButton"
+          onClick={this.alignRight}
+          style={{ marginLeft: '0.9em' }}
+          role="button"
+          key="right"
+        >
+          R
+        </span>
+        <span
+          className="alignmentButton"
+          onClick={this.alignCenterSmall}
+          style={{ marginLeft: '2.6em' }}
+          role="button"
+          key="center-small"
+        >
+          S
+        </span>
+      </div>
+    );
 
-		const device = _.get(this.props, ['blockProps', 'device'], 'mobile');
-		let BlockComponent;
-		let style;
+    const device = _.get(this.props, ['blockProps', 'device'], 'mobile');
+    let BlockComponent;
+    let style;
 
-		switch (type) {
-			case ENTITY.AUDIO.type:
-				BlockComponent = AudioBlock;
-				if (device === 'mobile') {
-					style = mobileStyle;
-				} else {
-					style = tabletMinStyle;
-				}
-				break;
-			case ENTITY.BLOCKQUOTE.type:
-				BlockComponent = BlockQuoteBlock;
-				if (device === 'mobile') {
-					style = mobileStyle;
-				} else {
-					style = tabletMinStyle;
-				}
-				break;
-			case ENTITY.EMBEDDEDCODE.type:
-				BlockComponent = EmbeddedCodeBlock;
-				if (device === 'mobile') {
-					style = mobileStyle;
-				} else {
-					style = tabletMinStyle;
-				}
-				break;
-			case ENTITY.INFOBOX.type:
-				BlockComponent = InfoBoxBlock;
-				if (device === 'mobile') {
-					style = mobileStyle;
-				} else {
-					style = tabletMinStyle;
-				}
-				break;
-			case ENTITY.IMAGE.type:
-				BlockComponent = ImageBlock;
-				if (device === 'mobile') {
-					style = mobileStyle;
-				} else {
-					style = tabletMaxStyle;
-				}
-				break;
-			case ENTITY.IMAGELINK.type:
-				BlockComponent = ImageLinkBlock;
-				if (device === 'mobile') {
-					style = mobileStyle;
-				} else {
-					style = tabletMaxStyle;
-				}
-				break;
-			case ENTITY.SLIDESHOW.type:
-				BlockComponent = SlideshowBlock;
-				if (device === 'mobile') {
-					style = mobileStyle;
-				} else {
-					style = tabletMaxStyle;
-				}
-				break;
-			case ENTITY.IMAGEDIFF.type:
-				BlockComponent = ImageDiffBlock;
-				if (device === 'mobile') {
-					style = mobileStyle;
-				} else {
-					style = tabletMaxStyle;
-				}
-				break;
-			case ENTITY.YOUTUBE.type:
-				BlockComponent = YoutubeBlock;
-				if (device === 'mobile') {
-					style = mobileStyle;
-				} else {
-					style = tabletMaxStyle;
-				}
-				break;
-			default:
-				return null;
-		}
-		if (!BlockComponent) {
-			return null;
-		}
+    switch (type) {
+      case ENTITY.AUDIO.type:
+        BlockComponent = AudioBlock;
+        if (device === 'mobile') {
+          style = mobileStyle;
+        } else {
+          style = tabletMinStyle;
+        }
+        break;
+      case ENTITY.BLOCKQUOTE.type:
+        BlockComponent = BlockQuoteBlock;
+        if (device === 'mobile') {
+          style = mobileStyle;
+        } else {
+          style = tabletMinStyle;
+        }
+        break;
+      case ENTITY.EMBEDDEDCODE.type:
+        BlockComponent = EmbeddedCodeBlock;
+        if (device === 'mobile') {
+          style = mobileStyle;
+        } else {
+          style = tabletMinStyle;
+        }
+        break;
+      case ENTITY.INFOBOX.type:
+        BlockComponent = InfoBoxBlock;
+        if (device === 'mobile') {
+          style = mobileStyle;
+        } else {
+          style = tabletMinStyle;
+        }
+        break;
+      case ENTITY.IMAGE.type:
+        BlockComponent = ImageBlock;
+        if (device === 'mobile') {
+          style = mobileStyle;
+        } else {
+          style = tabletMaxStyle;
+        }
+        break;
+      case ENTITY.IMAGELINK.type:
+        BlockComponent = ImageLinkBlock;
+        if (device === 'mobile') {
+          style = mobileStyle;
+        } else {
+          style = tabletMaxStyle;
+        }
+        break;
+      case ENTITY.SLIDESHOW.type:
+        BlockComponent = SlideshowBlock;
+        if (device === 'mobile') {
+          style = mobileStyle;
+        } else {
+          style = tabletMaxStyle;
+        }
+        break;
+      case ENTITY.IMAGEDIFF.type:
+        BlockComponent = ImageDiffBlock;
+        if (device === 'mobile') {
+          style = mobileStyle;
+        } else {
+          style = tabletMaxStyle;
+        }
+        break;
+      case ENTITY.YOUTUBE.type:
+        BlockComponent = YoutubeBlock;
+        if (device === 'mobile') {
+          style = mobileStyle;
+        } else {
+          style = tabletMaxStyle;
+        }
+        break;
+      default:
+        return null;
+    }
+    if (!BlockComponent) {
+      return null;
+    }
 
-		return (
-			<div className={classNames('center-block')} style={style}>
-				<BlockComponent {...this.props} device={device}>
-					{device !== 'mobile' ? Buttons : null}
-				</BlockComponent>
-			</div>
-		);
-	}
+    return (
+      <div className={classNames('center-block')} style={style}>
+        <BlockComponent {...this.props} device={device}>
+          {device !== 'mobile' ? Buttons : null}
+        </BlockComponent>
+      </div>
+    );
+  }
 }
 
 export default Wrapper(AtomicBlockSwitcher);

--- a/fields/types/html/editor/base/atomic-block-switcher.js
+++ b/fields/types/html/editor/base/atomic-block-switcher.js
@@ -14,7 +14,6 @@ import Wrapper from './block-wrapper';
 import YoutubeBlock from '../youtube/youtube-block';
 import classNames from 'classnames';
 import get from 'lodash/get';
-import { Entity } from 'draft-js';
 import { mobileStyle, tabletMinStyle, tabletMaxStyle } from '../constants/layout-style';
 
 const _ = {
@@ -50,9 +49,9 @@ class AtomicBlockSwitcher extends React.Component {
         this.props.align('center-small')
     }
 
-	render () {
-		const entityKey = this.props.block.getEntityAt(0);
-		let type = entityKey ? Entity.get(entityKey).getType() : '';
+  render () {
+    const entityKey = this.props.block.getEntityAt(0);
+		let type = entityKey ? this.props.contentState.getEntity(entityKey).getType() : '';
 		// backward compatible. Old data type is lower case
 		type = type && type.toUpperCase();
 

--- a/fields/types/html/editor/base/block-wrapper.js
+++ b/fields/types/html/editor/base/block-wrapper.js
@@ -1,5 +1,4 @@
 'use strict';
-import { Entity } from 'draft-js';
 import React, { Component } from 'react';
 import get from 'lodash/get';
 
@@ -31,7 +30,7 @@ export default function WrapComponent (WrappedComponent) {
 		_align (alignment) {
 			const entityKey = this.props.block.getEntityAt(0);
       if (entityKey) {
-        Entity.mergeData(entityKey, { alignment });
+        this.props.contentState.mergeEntityData(entityKey, { alignment });
 				this.setState({ alignment });
 
 				// Force refresh

--- a/fields/types/html/editor/base/block-wrapper.js
+++ b/fields/types/html/editor/base/block-wrapper.js
@@ -19,8 +19,8 @@ export default function WrapComponent (WrappedComponent) {
 
 			const entityKey = this.props.block.getEntityAt(0);
 			let alignment;
-			if (entityKey) {
-				alignment = _.get(Entity.get(entityKey).get('data'), 'alignment', 'center');
+      if (entityKey) {
+				alignment = _.get(this.props.contentState.getEntity(entityKey).get('data'), 'alignment', 'center');
 			}
 			this.state = {
 				alignment: alignment,
@@ -30,8 +30,8 @@ export default function WrapComponent (WrappedComponent) {
 
 		_align (alignment) {
 			const entityKey = this.props.block.getEntityAt(0);
-			if (entityKey) {
-				Entity.mergeData(entityKey, { alignment });
+      if (entityKey) {
+        Entity.mergeData(entityKey, { alignment });
 				this.setState({ alignment });
 
 				// Force refresh

--- a/fields/types/html/editor/base/block-wrapper.js
+++ b/fields/types/html/editor/base/block-wrapper.js
@@ -3,23 +3,26 @@ import React, { Component } from 'react';
 import get from 'lodash/get';
 
 const _ = {
-  get,
-}
+	get,
+};
 
-const getDisplayName = (WrappedComponent) => (
-	WrappedComponent.displayName || WrappedComponent.name || 'Component'
-);
+const getDisplayName = (WrappedComponent) =>
+	WrappedComponent.displayName || WrappedComponent.name || 'Component';
 
 // Export
-export default function WrapComponent (WrappedComponent) {
+export default function WrapComponent(WrappedComponent) {
 	class Wrapper extends Component {
-		constructor (props) {
+		constructor(props) {
 			super(props);
 
 			const entityKey = this.props.block.getEntityAt(0);
 			let alignment;
-      if (entityKey) {
-				alignment = _.get(this.props.contentState.getEntity(entityKey).get('data'), 'alignment', 'center');
+			if (entityKey) {
+				alignment = _.get(
+					this.props.contentState.getEntity(entityKey).get('data'),
+					'alignment',
+					'center'
+				);
 			}
 			this.state = {
 				alignment: alignment,
@@ -27,10 +30,10 @@ export default function WrapComponent (WrappedComponent) {
 			this.align = this._align.bind(this);
 		}
 
-		_align (alignment) {
+		_align(alignment) {
 			const entityKey = this.props.block.getEntityAt(0);
-      if (entityKey) {
-        this.props.contentState.mergeEntityData(entityKey, { alignment });
+			if (entityKey) {
+				this.props.contentState.mergeEntityData(entityKey, { alignment });
 				this.setState({ alignment });
 
 				// Force refresh
@@ -38,13 +41,11 @@ export default function WrapComponent (WrappedComponent) {
 			}
 		}
 
-		render () {
+		render() {
 			// let clearfix = this.state.alignment !== 'center' ? true : false;
 			return (
 				<div>
-					<WrappedComponent {...this.props}
-						align={this.align}
-					/>
+					<WrappedComponent {...this.props} align={this.align} />
 				</div>
 			);
 		}

--- a/fields/types/html/editor/base/block-wrapper.js
+++ b/fields/types/html/editor/base/block-wrapper.js
@@ -3,57 +3,57 @@ import React, { Component } from 'react';
 import get from 'lodash/get';
 
 const _ = {
-	get,
+  get,
 };
 
 const getDisplayName = (WrappedComponent) =>
-	WrappedComponent.displayName || WrappedComponent.name || 'Component';
+  WrappedComponent.displayName || WrappedComponent.name || 'Component';
 
 // Export
 export default function WrapComponent(WrappedComponent) {
-	class Wrapper extends Component {
-		constructor(props) {
-			super(props);
+  class Wrapper extends Component {
+    constructor(props) {
+      super(props);
 
-			const entityKey = this.props.block.getEntityAt(0);
-			let alignment;
-			if (entityKey) {
-				alignment = _.get(
-					this.props.contentState.getEntity(entityKey).get('data'),
-					'alignment',
-					'center'
-				);
-			}
-			this.state = {
-				alignment: alignment,
-			};
-			this.align = this._align.bind(this);
-		}
+      const entityKey = this.props.block.getEntityAt(0);
+      let alignment;
+      if (entityKey) {
+        alignment = _.get(
+          this.props.contentState.getEntity(entityKey).get('data'),
+          'alignment',
+          'center'
+        );
+      }
+      this.state = {
+        alignment: alignment,
+      };
+      this.align = this._align.bind(this);
+    }
 
-		_align(alignment) {
-			const entityKey = this.props.block.getEntityAt(0);
-			if (entityKey) {
-				this.props.contentState.mergeEntityData(entityKey, { alignment });
-				this.setState({ alignment });
+    _align(alignment) {
+      const entityKey = this.props.block.getEntityAt(0);
+      if (entityKey) {
+        this.props.contentState.mergeEntityData(entityKey, { alignment });
+        this.setState({ alignment });
 
-				// Force refresh
-				this.props.blockProps.refreshEditorState();
-			}
-		}
+        // Force refresh
+        this.props.blockProps.refreshEditorState();
+      }
+    }
 
-		render() {
-			// let clearfix = this.state.alignment !== 'center' ? true : false;
-			return (
-				<div>
-					<WrappedComponent {...this.props} align={this.align} />
-				</div>
-			);
-		}
-	}
-	Wrapper.displayName = `Decorated(${getDisplayName(WrappedComponent)})`;
-	Wrapper.defaultProps = {
-		readOnly: false,
-	};
+    render() {
+      // let clearfix = this.state.alignment !== 'center' ? true : false;
+      return (
+        <div>
+          <WrappedComponent {...this.props} align={this.align} />
+        </div>
+      );
+    }
+  }
+  Wrapper.displayName = `Decorated(${getDisplayName(WrappedComponent)})`;
+  Wrapper.defaultProps = {
+    readOnly: false,
+  };
 
-	return Wrapper;
+  return Wrapper;
 }

--- a/fields/types/html/editor/editor-buttons.js
+++ b/fields/types/html/editor/editor-buttons.js
@@ -14,265 +14,265 @@ import YoutubeBt from './youtube/youtube-bt';
 import map from 'lodash/map';
 
 const _ = {
-	map,
+  map,
 };
 
 class StyleButton extends React.Component {
-	constructor() {
-		super();
-		this.onToggle = (e) => {
-			e.preventDefault();
-			this.props.onToggle(this.props.style);
-		};
-	}
+  constructor() {
+    super();
+    this.onToggle = (e) => {
+      e.preventDefault();
+      this.props.onToggle(this.props.style);
+    };
+  }
 
-	render() {
-		let className = '';
-		if (this.props.active) {
-			className += ' RichEditor-activeButton';
-		}
+  render() {
+    let className = '';
+    if (this.props.active) {
+      className += ' RichEditor-activeButton';
+    }
 
-		return (
-			<Button
-				type="default"
-				className={className + ' tooltip-box'}
-				onMouseDown={this.onToggle}
-				data-tooltip={this.props.label}
-			>
-				<i className={'fa ' + this.props.icon}></i>
-				<span>{this.props.text}</span>
-			</Button>
-		);
-	}
+    return (
+      <Button
+        type="default"
+        className={className + ' tooltip-box'}
+        onMouseDown={this.onToggle}
+        data-tooltip={this.props.label}
+      >
+        <i className={'fa ' + this.props.icon}></i>
+        <span>{this.props.text}</span>
+      </Button>
+    );
+  }
 }
 
 export const BlockStyleButtons = (props) => {
-	const { editorState, buttons, onToggle } = props;
-	const selection = editorState.getSelection();
-	const blockType = editorState
-		.getCurrentContent()
-		.getBlockForKey(selection.getStartKey())
-		.getType();
-	return (
-		<ButtonGroup>
-			{_.map(buttons, (button) => (
-				<StyleButton
-					key={button.label}
-					active={button.style === blockType}
-					label={button.label}
-					onToggle={onToggle}
-					style={button.style}
-					icon={button.icon}
-					text={button.text}
-				/>
-			))}
-		</ButtonGroup>
-	);
+  const { editorState, buttons, onToggle } = props;
+  const selection = editorState.getSelection();
+  const blockType = editorState
+    .getCurrentContent()
+    .getBlockForKey(selection.getStartKey())
+    .getType();
+  return (
+    <ButtonGroup>
+      {_.map(buttons, (button) => (
+        <StyleButton
+          key={button.label}
+          active={button.style === blockType}
+          label={button.label}
+          onToggle={onToggle}
+          style={button.style}
+          icon={button.icon}
+          text={button.text}
+        />
+      ))}
+    </ButtonGroup>
+  );
 };
 
 export const InlineStyleButtons = (props) => {
-	const { editorState, buttons, onToggle } = props;
-	let currentStyle = editorState.getCurrentInlineStyle();
-	return (
-		<ButtonGroup>
-			{_.map(buttons, (button) => (
-				<StyleButton
-					key={button.label}
-					active={currentStyle.has(button.style)}
-					label={button.label}
-					onToggle={onToggle}
-					style={button.style}
-					icon={button.icon}
-					text={button.text}
-				/>
-			))}
-		</ButtonGroup>
-	);
+  const { editorState, buttons, onToggle } = props;
+  let currentStyle = editorState.getCurrentInlineStyle();
+  return (
+    <ButtonGroup>
+      {_.map(buttons, (button) => (
+        <StyleButton
+          key={button.label}
+          active={currentStyle.has(button.style)}
+          label={button.label}
+          onToggle={onToggle}
+          style={button.style}
+          icon={button.icon}
+          text={button.text}
+        />
+      ))}
+    </ButtonGroup>
+  );
 };
 
 export const EntityButtons = (props) => {
-	const { editorState, entities } = props;
-	const selection = editorState.getSelection();
-	const startOffset = selection.getStartOffset();
-	const contentState = editorState.getCurrentContent();
-	const startBlock = contentState.getBlockForKey(selection.getStartKey());
+  const { editorState, entities } = props;
+  const selection = editorState.getSelection();
+  const startOffset = selection.getStartOffset();
+  const contentState = editorState.getCurrentContent();
+  const startBlock = contentState.getBlockForKey(selection.getStartKey());
 
-	const endOffset = selection.getEndOffset();
-	let data;
-	let entityInstance;
-	let entityKey;
-	let selectedText = '';
+  const endOffset = selection.getEndOffset();
+  let data;
+  let entityInstance;
+  let entityKey;
+  let selectedText = '';
 
-	if (!selection.isCollapsed()) {
-		const blockText = startBlock.getText();
-		selectedText = blockText.slice(startOffset, endOffset);
-		entityKey = startBlock.getEntityAt(startOffset);
-	} else {
-		entityKey = startBlock.getEntityAt(0);
-	}
+  if (!selection.isCollapsed()) {
+    const blockText = startBlock.getText();
+    selectedText = blockText.slice(startOffset, endOffset);
+    entityKey = startBlock.getEntityAt(startOffset);
+  } else {
+    entityKey = startBlock.getEntityAt(0);
+  }
 
-	if (entityKey !== null) {
-		entityInstance = contentState.getEntity(entityKey);
-		data = entityInstance.getData();
-	}
+  if (entityKey !== null) {
+    entityInstance = contentState.getEntity(entityKey);
+    data = entityInstance.getData();
+  }
 
-	function _onToggle(entity, changedValue) {
-		props.onToggle(entity, changedValue);
-	}
+  function _onToggle(entity, changedValue) {
+    props.onToggle(entity, changedValue);
+  }
 
-	function chooseButton(entity) {
-		let active = entityInstance ? entityInstance.getType() === entity : false;
-		let onToggle = _onToggle.bind(null, entity);
-		switch (entity) {
-			case ENTITY.ANNOTATION.type:
-				return (
-					<AnnotationBt
-						active={active}
-						annotation={data ? data.annotation : ''}
-						draftRawObj={data ? data.draftRawObj : null}
-						icon="fa-pencil-square-o"
-						iconText=""
-						key={entity}
-						label={entity}
-						onToggle={onToggle}
-						text={data ? data.text : selectedText}
-					/>
-				);
-			case ENTITY.AUDIO.type:
-				return (
-					<AudioButton
-						active={active}
-						apiPath="audios"
-						key={entity}
-						label={entity}
-						onToggle={onToggle}
-						icon="fa-file-audio-o"
-						iconText=" Audio"
-					/>
-				);
-			case ENTITY.BLOCKQUOTE.type:
-				return (
-					<BlockQuoteBt
-						active={active}
-						key={entity}
-						label={entity}
-						onToggle={onToggle}
-						icon="fa-quote-right"
-						iconText=""
-						quote={data ? data.quote : selectedText}
-						quoteBy={data ? data.quoteBy : ''}
-					/>
-				);
-			case ENTITY.INFOBOX.type:
-				return (
-					<InfoBoxBt
-						active={active}
-						key={entity}
-						label={entity}
-						onToggle={onToggle}
-						title={data ? data.title : selectedText}
-						body={data ? data.body : ''}
-						icon=""
-						iconText="infobox"
-					/>
-				);
-			case ENTITY.LINK.type:
-				return (
-					<LinkButton
-						active={active}
-						key={entity}
-						label={entity}
-						onToggle={onToggle}
-						url={data ? data.url : ''}
-						text={data ? data.text : selectedText}
-						icon="fa-link"
-						iconText=""
-					/>
-				);
-			case ENTITY.IMAGE.type:
-				return (
-					<ImageButton
-						active={active}
-						apiPath="images"
-						key={entity}
-						label={entity}
-						onToggle={onToggle}
-						icon="fa-photo"
-						iconText=" Img"
-					/>
-				);
-			case ENTITY.SLIDESHOW.type:
-				return (
-					<ImageButton
-						active={active}
-						apiPath="images"
-						key={entity}
-						label={entity}
-						onToggle={onToggle}
-						selectionLimit={ENTITY.SLIDESHOW.slideshowSelectionLimit}
-						icon="fa-slideshare"
-						iconText=" Slideshow"
-					/>
-				);
-			case ENTITY.IMAGEDIFF.type:
-				return (
-					<ImageButton
-						active={active}
-						apiPath="images"
-						key={entity}
-						label={entity}
-						onToggle={onToggle}
-						selectionLimit={2}
-						icon="fa-object-ungroup"
-						iconText=" Diff"
-					/>
-				);
-			case ENTITY.IMAGELINK.type:
-				return (
-					<ImageLinkButton
-						active={active}
-						desc={data ? data.desc : ''}
-						key={entity}
-						label={entity}
-						onToggle={onToggle}
-						url={data ? data.url : ''}
-						icon="fa-external-link"
-						iconText=" ImgLink"
-					/>
-				);
-			case ENTITY.EMBEDDEDCODE.type:
-				return (
-					<EmbeddedCodeBt
-						active={active}
-						key={entity}
-						label={entity}
-						onToggle={onToggle}
-						caption={data ? data.caption : ''}
-						embeddedCode={data ? data.embeddedCode : ''}
-						iconText=" Embed"
-					/>
-				);
-			case ENTITY.YOUTUBE.type:
-				return (
-					<YoutubeBt
-						active={active}
-						description={data ? data.description : ''}
-						key={entity}
-						label={entity}
-						onToggle={onToggle}
-						icon="fa-youtube fa-2"
-						iconText=""
-						youtubeId={data ? data.youtubeId : ''}
-					/>
-				);
-			default:
-				return;
-		}
-	}
+  function chooseButton(entity) {
+    let active = entityInstance ? entityInstance.getType() === entity : false;
+    let onToggle = _onToggle.bind(null, entity);
+    switch (entity) {
+      case ENTITY.ANNOTATION.type:
+        return (
+          <AnnotationBt
+            active={active}
+            annotation={data ? data.annotation : ''}
+            draftRawObj={data ? data.draftRawObj : null}
+            icon="fa-pencil-square-o"
+            iconText=""
+            key={entity}
+            label={entity}
+            onToggle={onToggle}
+            text={data ? data.text : selectedText}
+          />
+        );
+      case ENTITY.AUDIO.type:
+        return (
+          <AudioButton
+            active={active}
+            apiPath="audios"
+            key={entity}
+            label={entity}
+            onToggle={onToggle}
+            icon="fa-file-audio-o"
+            iconText=" Audio"
+          />
+        );
+      case ENTITY.BLOCKQUOTE.type:
+        return (
+          <BlockQuoteBt
+            active={active}
+            key={entity}
+            label={entity}
+            onToggle={onToggle}
+            icon="fa-quote-right"
+            iconText=""
+            quote={data ? data.quote : selectedText}
+            quoteBy={data ? data.quoteBy : ''}
+          />
+        );
+      case ENTITY.INFOBOX.type:
+        return (
+          <InfoBoxBt
+            active={active}
+            key={entity}
+            label={entity}
+            onToggle={onToggle}
+            title={data ? data.title : selectedText}
+            body={data ? data.body : ''}
+            icon=""
+            iconText="infobox"
+          />
+        );
+      case ENTITY.LINK.type:
+        return (
+          <LinkButton
+            active={active}
+            key={entity}
+            label={entity}
+            onToggle={onToggle}
+            url={data ? data.url : ''}
+            text={data ? data.text : selectedText}
+            icon="fa-link"
+            iconText=""
+          />
+        );
+      case ENTITY.IMAGE.type:
+        return (
+          <ImageButton
+            active={active}
+            apiPath="images"
+            key={entity}
+            label={entity}
+            onToggle={onToggle}
+            icon="fa-photo"
+            iconText=" Img"
+          />
+        );
+      case ENTITY.SLIDESHOW.type:
+        return (
+          <ImageButton
+            active={active}
+            apiPath="images"
+            key={entity}
+            label={entity}
+            onToggle={onToggle}
+            selectionLimit={ENTITY.SLIDESHOW.slideshowSelectionLimit}
+            icon="fa-slideshare"
+            iconText=" Slideshow"
+          />
+        );
+      case ENTITY.IMAGEDIFF.type:
+        return (
+          <ImageButton
+            active={active}
+            apiPath="images"
+            key={entity}
+            label={entity}
+            onToggle={onToggle}
+            selectionLimit={2}
+            icon="fa-object-ungroup"
+            iconText=" Diff"
+          />
+        );
+      case ENTITY.IMAGELINK.type:
+        return (
+          <ImageLinkButton
+            active={active}
+            desc={data ? data.desc : ''}
+            key={entity}
+            label={entity}
+            onToggle={onToggle}
+            url={data ? data.url : ''}
+            icon="fa-external-link"
+            iconText=" ImgLink"
+          />
+        );
+      case ENTITY.EMBEDDEDCODE.type:
+        return (
+          <EmbeddedCodeBt
+            active={active}
+            key={entity}
+            label={entity}
+            onToggle={onToggle}
+            caption={data ? data.caption : ''}
+            embeddedCode={data ? data.embeddedCode : ''}
+            iconText=" Embed"
+          />
+        );
+      case ENTITY.YOUTUBE.type:
+        return (
+          <YoutubeBt
+            active={active}
+            description={data ? data.description : ''}
+            key={entity}
+            label={entity}
+            onToggle={onToggle}
+            icon="fa-youtube fa-2"
+            iconText=""
+            youtubeId={data ? data.youtubeId : ''}
+          />
+        );
+      default:
+        return;
+    }
+  }
 
-	return (
-		<ButtonGroup>
-			{_.map(entities, (entity) => chooseButton(entity))}
-		</ButtonGroup>
-	);
+  return (
+    <ButtonGroup>
+      {_.map(entities, (entity) => chooseButton(entity))}
+    </ButtonGroup>
+  );
 };

--- a/fields/types/html/editor/editor-buttons.js
+++ b/fields/types/html/editor/editor-buttons.js
@@ -1,6 +1,5 @@
 'use strict';
 import { Button, ButtonGroup } from 'elemental';
-import { Entity } from 'draft-js';
 import AnnotationBt from './annotation/annotation-bt';
 import AudioButton from './audio/audio-bt';
 import BlockQuoteBt from './quote/block-quote-bt';
@@ -95,8 +94,8 @@ export const EntityButtons = (props) => {
 	const { editorState, entities } = props;
 	const selection = editorState.getSelection();
 	const startOffset = selection.getStartOffset();
-	const startBlock = editorState
-		.getCurrentContent()
+	const contentState = editorState.getCurrentContent();
+	const startBlock = contentState 
 		.getBlockForKey(selection.getStartKey());
 
 	const endOffset = selection.getEndOffset();
@@ -114,7 +113,7 @@ export const EntityButtons = (props) => {
 	}
 
 	if (entityKey !== null) {
-		entityInstance = Entity.get(entityKey);
+    entityInstance = contentState.getEntity(entityKey)
 		data = entityInstance.getData();
 	}
 

--- a/fields/types/html/editor/editor-buttons.js
+++ b/fields/types/html/editor/editor-buttons.js
@@ -14,11 +14,11 @@ import YoutubeBt from './youtube/youtube-bt';
 import map from 'lodash/map';
 
 const _ = {
-  map,
-}
+	map,
+};
 
 class StyleButton extends React.Component {
-	constructor () {
+	constructor() {
 		super();
 		this.onToggle = (e) => {
 			e.preventDefault();
@@ -26,7 +26,7 @@ class StyleButton extends React.Component {
 		};
 	}
 
-	render () {
+	render() {
 		let className = '';
 		if (this.props.active) {
 			className += ' RichEditor-activeButton';
@@ -37,7 +37,8 @@ class StyleButton extends React.Component {
 				type="default"
 				className={className + ' tooltip-box'}
 				onMouseDown={this.onToggle}
-				data-tooltip={this.props.label}>
+				data-tooltip={this.props.label}
+			>
 				<i className={'fa ' + this.props.icon}></i>
 				<span>{this.props.text}</span>
 			</Button>
@@ -54,7 +55,7 @@ export const BlockStyleButtons = (props) => {
 		.getType();
 	return (
 		<ButtonGroup>
-			{_.map(buttons, (button) =>
+			{_.map(buttons, (button) => (
 				<StyleButton
 					key={button.label}
 					active={button.style === blockType}
@@ -64,18 +65,17 @@ export const BlockStyleButtons = (props) => {
 					icon={button.icon}
 					text={button.text}
 				/>
-			)}
+			))}
 		</ButtonGroup>
 	);
 };
-
 
 export const InlineStyleButtons = (props) => {
 	const { editorState, buttons, onToggle } = props;
 	let currentStyle = editorState.getCurrentInlineStyle();
 	return (
 		<ButtonGroup>
-			{_.map(buttons, (button) =>
+			{_.map(buttons, (button) => (
 				<StyleButton
 					key={button.label}
 					active={currentStyle.has(button.style)}
@@ -85,7 +85,7 @@ export const InlineStyleButtons = (props) => {
 					icon={button.icon}
 					text={button.text}
 				/>
-			)}
+			))}
 		</ButtonGroup>
 	);
 };
@@ -95,8 +95,7 @@ export const EntityButtons = (props) => {
 	const selection = editorState.getSelection();
 	const startOffset = selection.getStartOffset();
 	const contentState = editorState.getCurrentContent();
-	const startBlock = contentState 
-		.getBlockForKey(selection.getStartKey());
+	const startBlock = contentState.getBlockForKey(selection.getStartKey());
 
 	const endOffset = selection.getEndOffset();
 	let data;
@@ -113,15 +112,15 @@ export const EntityButtons = (props) => {
 	}
 
 	if (entityKey !== null) {
-    entityInstance = contentState.getEntity(entityKey)
+		entityInstance = contentState.getEntity(entityKey);
 		data = entityInstance.getData();
 	}
 
-	function _onToggle (entity, changedValue) {
+	function _onToggle(entity, changedValue) {
 		props.onToggle(entity, changedValue);
 	}
 
-	function chooseButton (entity) {
+	function chooseButton(entity) {
 		let active = entityInstance ? entityInstance.getType() === entity : false;
 		let onToggle = _onToggle.bind(null, entity);
 		switch (entity) {
@@ -273,7 +272,7 @@ export const EntityButtons = (props) => {
 
 	return (
 		<ButtonGroup>
-			{_.map(entities, entity => chooseButton(entity))}
+			{_.map(entities, (entity) => chooseButton(entity))}
 		</ButtonGroup>
 	);
 };

--- a/fields/types/html/editor/entity-decorator.js
+++ b/fields/types/html/editor/entity-decorator.js
@@ -7,9 +7,9 @@ import linkDecorator from './link/link-decorator';
 import quoteDecorator from './quote/quote-decorator';
 
 const decorator = new CompositeDecorator([
-	annotationDecorator,
-	linkDecorator,
-	quoteDecorator,
+  annotationDecorator,
+  linkDecorator,
+  quoteDecorator,
 ]);
 
 export default decorator;

--- a/fields/types/html/editor/entity-decorator.js
+++ b/fields/types/html/editor/entity-decorator.js
@@ -6,6 +6,10 @@ import annotationDecorator from './annotation/annotation-decorator';
 import linkDecorator from './link/link-decorator';
 import quoteDecorator from './quote/quote-decorator';
 
-const decorator = new CompositeDecorator([annotationDecorator, linkDecorator, quoteDecorator]);
+const decorator = new CompositeDecorator([
+	annotationDecorator,
+	linkDecorator,
+	quoteDecorator,
+]);
 
 export default decorator;

--- a/fields/types/html/editor/entity-decorator.js
+++ b/fields/types/html/editor/entity-decorator.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { CompositeDecorator } from 'draft-js';
+import { CompositeDecorator } from '@twreporter/draft-js';
 import React from 'react'; // eslint-disable-line no-unused-vars
 import annotationDecorator from './annotation/annotation-decorator';
 import linkDecorator from './link/link-decorator';

--- a/fields/types/html/editor/info-box/info-box-editing-block.js
+++ b/fields/types/html/editor/info-box/info-box-editing-block.js
@@ -5,62 +5,62 @@ import EntityEditingBlockMixin from '../mixins/entity-editing-block-mixin';
 import React from 'react';
 
 class InfoBoxEditingBlock extends EntityEditingBlockMixin(React.Component) {
-	constructor(props) {
-		super(props);
-		this.state.editorState = this._initEditorState(props.draftRawObj);
-	}
+  constructor(props) {
+    super(props);
+    this.state.editorState = this._initEditorState(props.draftRawObj);
+  }
 
-	// overwrite EntityEditingBlock._composeEditingFields
-	_composeEditingFields(props) {
-		return {
-			title: {
-				type: 'text',
-				value: props.title,
-			},
-			body: {
-				type: 'html',
-				value: props.body,
-			},
-		};
-	}
+  // overwrite EntityEditingBlock._composeEditingFields
+  _composeEditingFields(props) {
+    return {
+      title: {
+        type: 'text',
+        value: props.title,
+      },
+      body: {
+        type: 'html',
+        value: props.body,
+      },
+    };
+  }
 
-	// overwrite EntityEditingBlock._decomposeEditingFields
-	_decomposeEditingFields(fields) {
-		let { editorState } = this.state;
-		const content = convertToRaw(editorState.getCurrentContent());
-		const cHtml = DraftConverter.convertToHtml(content);
-		return {
-			title: fields.title.value,
-			body: cHtml,
-			draftRawObj: content,
-		};
-	}
+  // overwrite EntityEditingBlock._decomposeEditingFields
+  _decomposeEditingFields(fields) {
+    let { editorState } = this.state;
+    const content = convertToRaw(editorState.getCurrentContent());
+    const cHtml = DraftConverter.convertToHtml(content);
+    return {
+      title: fields.title.value,
+      body: cHtml,
+      draftRawObj: content,
+    };
+  }
 
-	// overwrite EntityEditingBlock._handleEditingFieldChange
-	_handleEditingFieldChange(field, e) {
-		if (field === 'body') {
-			return;
-		}
-		return super._handleEditingFieldChange(field, e);
-	}
+  // overwrite EntityEditingBlock._handleEditingFieldChange
+  _handleEditingFieldChange(field, e) {
+    if (field === 'body') {
+      return;
+    }
+    return super._handleEditingFieldChange(field, e);
+  }
 }
 
 InfoBoxEditingBlock.displayName = 'InfoBoxEditingBlock';
 
 InfoBoxEditingBlock.propTypes = {
-	body: React.PropTypes.string,
-	draftRawObj: React.PropTypes.object,
-	isModalOpen: React.PropTypes.bool,
-	onToggle: React.PropTypes.func.isRequired,
-	title: React.PropTypes.string,
-	toggleModal: React.PropTypes.func,
+  body: React.PropTypes.string,
+  draftRawObj: React.PropTypes.object,
+  isModalOpen: React.PropTypes.bool,
+  onToggle: React.PropTypes.func.isRequired,
+  title: React.PropTypes.string,
+  toggleModal: React.PropTypes.func,
 };
 
 InfoBoxEditingBlock.defaultProps = {
-	body: '',
-	draftRawObj: null,
-	isModalOpen: false,
-	title: '',
+  body: '',
+  draftRawObj: null,
+  isModalOpen: false,
+  title: '',
 };
 
 export default InfoBoxEditingBlock;

--- a/fields/types/html/editor/info-box/info-box-editing-block.js
+++ b/fields/types/html/editor/info-box/info-box-editing-block.js
@@ -5,13 +5,13 @@ import EntityEditingBlockMixin from '../mixins/entity-editing-block-mixin';
 import React from 'react';
 
 class InfoBoxEditingBlock extends EntityEditingBlockMixin(React.Component) {
-	constructor (props) {
+	constructor(props) {
 		super(props);
 		this.state.editorState = this._initEditorState(props.draftRawObj);
 	}
 
 	// overwrite EntityEditingBlock._composeEditingFields
-	_composeEditingFields (props) {
+	_composeEditingFields(props) {
 		return {
 			title: {
 				type: 'text',
@@ -24,9 +24,8 @@ class InfoBoxEditingBlock extends EntityEditingBlockMixin(React.Component) {
 		};
 	}
 
-
 	// overwrite EntityEditingBlock._decomposeEditingFields
-	_decomposeEditingFields (fields) {
+	_decomposeEditingFields(fields) {
 		let { editorState } = this.state;
 		const content = convertToRaw(editorState.getCurrentContent());
 		const cHtml = DraftConverter.convertToHtml(content);
@@ -38,13 +37,13 @@ class InfoBoxEditingBlock extends EntityEditingBlockMixin(React.Component) {
 	}
 
 	// overwrite EntityEditingBlock._handleEditingFieldChange
-	_handleEditingFieldChange (field, e) {
+	_handleEditingFieldChange(field, e) {
 		if (field === 'body') {
 			return;
 		}
 		return super._handleEditingFieldChange(field, e);
 	}
-};
+}
 
 InfoBoxEditingBlock.displayName = 'InfoBoxEditingBlock';
 

--- a/fields/types/html/editor/info-box/info-box-editing-block.js
+++ b/fields/types/html/editor/info-box/info-box-editing-block.js
@@ -1,5 +1,5 @@
 'use strict';
-import { convertToRaw } from 'draft-js';
+import { convertToRaw } from '@twreporter/draft-js';
 import DraftConverter from '../draft-converter';
 import EntityEditingBlockMixin from '../mixins/entity-editing-block-mixin';
 import React from 'react';

--- a/fields/types/html/editor/link/link-decorator.js
+++ b/fields/types/html/editor/link/link-decorator.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Entity } from 'draft-js';
 import ENTITY from '../entities';
 
 const styles = {
@@ -10,7 +9,8 @@ const styles = {
 };
 
 const Link = (props) => {
-	const { url } = Entity.get(props.entityKey).getData();
+  const { contentState, entityKey } = props
+	const { url } = contentState.getEntity(entityKey).getData();
 	return (
 		<a href={url} style={styles.link}>
 			{props.children}
@@ -18,12 +18,12 @@ const Link = (props) => {
 	);
 };
 
-function findLinkEntities (contentBlock, callback) {
+function findLinkEntities (contentBlock, callback, contentState) {
 	contentBlock.findEntityRanges(
 		(character) => {
 			const entityKey = character.getEntity();
 			if (entityKey !== null) {
-				let type = Entity.get(entityKey).getType();
+				let type = contentState.getEntity(entityKey).getType();
 				type = type && type.toUpperCase();
 				return type === ENTITY.LINK.type;
 			}

--- a/fields/types/html/editor/link/link-decorator.js
+++ b/fields/types/html/editor/link/link-decorator.js
@@ -9,7 +9,7 @@ const styles = {
 };
 
 const Link = (props) => {
-  const { contentState, entityKey } = props
+	const { contentState, entityKey } = props;
 	const { url } = contentState.getEntity(entityKey).getData();
 	return (
 		<a href={url} style={styles.link}>
@@ -18,19 +18,16 @@ const Link = (props) => {
 	);
 };
 
-function findLinkEntities (contentBlock, callback, contentState) {
-	contentBlock.findEntityRanges(
-		(character) => {
-			const entityKey = character.getEntity();
-			if (entityKey !== null) {
-				let type = contentState.getEntity(entityKey).getType();
-				type = type && type.toUpperCase();
-				return type === ENTITY.LINK.type;
-			}
-			return false;
-		},
-		callback
-	);
+function findLinkEntities(contentBlock, callback, contentState) {
+	contentBlock.findEntityRanges((character) => {
+		const entityKey = character.getEntity();
+		if (entityKey !== null) {
+			let type = contentState.getEntity(entityKey).getType();
+			type = type && type.toUpperCase();
+			return type === ENTITY.LINK.type;
+		}
+		return false;
+	}, callback);
 }
 
 export default { strategy: findLinkEntities, component: Link };

--- a/fields/types/html/editor/link/link-decorator.js
+++ b/fields/types/html/editor/link/link-decorator.js
@@ -2,32 +2,32 @@ import React from 'react';
 import ENTITY from '../entities';
 
 const styles = {
-	link: {
-		color: '#3b5998',
-		textDecoration: 'underline',
-	},
+  link: {
+    color: '#3b5998',
+    textDecoration: 'underline',
+  },
 };
 
 const Link = (props) => {
-	const { contentState, entityKey } = props;
-	const { url } = contentState.getEntity(entityKey).getData();
-	return (
-		<a href={url} style={styles.link}>
-			{props.children}
-		</a>
-	);
+  const { contentState, entityKey } = props;
+  const { url } = contentState.getEntity(entityKey).getData();
+  return (
+    <a href={url} style={styles.link}>
+      {props.children}
+    </a>
+  );
 };
 
 function findLinkEntities(contentBlock, callback, contentState) {
-	contentBlock.findEntityRanges((character) => {
-		const entityKey = character.getEntity();
-		if (entityKey !== null) {
-			let type = contentState.getEntity(entityKey).getType();
-			type = type && type.toUpperCase();
-			return type === ENTITY.LINK.type;
-		}
-		return false;
-	}, callback);
+  contentBlock.findEntityRanges((character) => {
+    const entityKey = character.getEntity();
+    if (entityKey !== null) {
+      let type = contentState.getEntity(entityKey).getType();
+      type = type && type.toUpperCase();
+      return type === ENTITY.LINK.type;
+    }
+    return false;
+  }, callback);
 }
 
 export default { strategy: findLinkEntities, component: Link };

--- a/fields/types/html/editor/mixins/entity-editing-block-mixin.js
+++ b/fields/types/html/editor/mixins/entity-editing-block-mixin.js
@@ -93,9 +93,10 @@ let EntityEditingBlock = (superclass) => class extends Component {
 			html = html.replace(/<p|<h1|<h2|<h3|<h4|<h5|<h6/g, '<div').replace(/<\/p|<\/h1|<\/h2|<\/h3|<\/h4|<\/h5|<\/h6/g, '</div');
 
 			let editorState = this.state.editorState;
-			var htmlFragment = convertFromHTML(html);
+      const htmlFragment = convertFromHTML(html);
       if (htmlFragment) {
-        var htmlMap = BlockMapBuilder.createFromArray(htmlFragment);
+        const { contentBlocks, entityMap } = htmlFragment;
+        const htmlMap = BlockMapBuilder.createFromArray(contentBlocks);
 				this._handleEditorStateChange(insertFragment(editorState, htmlMap));
 				// prevent the default paste behavior.
 				return true;

--- a/fields/types/html/editor/mixins/entity-editing-block-mixin.js
+++ b/fields/types/html/editor/mixins/entity-editing-block-mixin.js
@@ -1,7 +1,21 @@
 'use strict';
 import { Button, FormField, FormInput, Modal } from 'elemental';
-import { BlockMapBuilder, Editor, EditorState, KeyBindingUtil, Modifier, RichUtils, convertFromHTML, convertFromRaw, getDefaultKeyBinding } from '@twreporter/draft-js';
-import { BlockStyleButtons, EntityButtons, InlineStyleButtons } from '../editor-buttons';
+import {
+	BlockMapBuilder,
+	Editor,
+	EditorState,
+	KeyBindingUtil,
+	Modifier,
+	RichUtils,
+	convertFromHTML,
+	convertFromRaw,
+	getDefaultKeyBinding,
+} from '@twreporter/draft-js';
+import {
+	BlockStyleButtons,
+	EntityButtons,
+	InlineStyleButtons,
+} from '../editor-buttons';
 import ENTITY from '../entities';
 import React, { Component } from 'react';
 import blockStyleFn from '../base/block-style-fn';
@@ -9,280 +23,313 @@ import decorator from '../entity-decorator';
 
 const { isCtrlKeyCommand } = KeyBindingUtil;
 
-let EntityEditingBlock = (superclass) => class extends Component {
-	constructor (props) {
-		super(props);
-		this.toggleModal = this._toggleModal.bind(this);
-		this.handleSave = this._handleSave.bind(this);
-		this.composeEditingFields = this._composeEditingFields.bind(this);
-		this.focus = this._focus.bind(this);
-		this._handleEditorStateChange = this._handleEditorStateChange.bind(this);
-		this._handleKeyCommand = this._handleKeyCommand.bind(this);
-		this._handlePastedText = this._handlePastedText.bind(this);
-		this._toggleBlockType = this._toggleBlockStyle.bind(this);
-		this._toggleInlineStyle = this._toggleInlineStyle.bind(this);
-		this._toggleEntity = this._toggleEntity.bind(this);
-		this._editingFields = this.composeEditingFields(props);
-		this.state = {
-			editingFields: this._editingFields,
-			editorState: EditorState.createEmpty(decorator),
-		};
-	}
-
-	componentWillReceiveProps (nextProps) {
-		this._editingFields = this.composeEditingFields(nextProps);
-		this.setState({
-			editingFields: this._editingFields,
-			editorState: this._initEditorState(nextProps.draftRawObj),
-		});
-	}
-
-	componentWillUnmount () {
-		this._editingFields = null;
-	}
-
-	_initEditorState (draftRawObj) {
-		let editorState;
-		if (draftRawObj) {
-			let contentState = convertFromRaw(draftRawObj);
-			editorState = EditorState.createWithContent(contentState, decorator);
-		} else {
-			editorState = EditorState.createEmpty(decorator);
-		}
-		return editorState;
-	}
-
-	// need to be overwrited
-	_handleEditorStateChange (editorState) {
-		this.setState({
-			editorState: editorState,
-		});
-	}
-
-	_handleKeyCommand (command) {
-		const { editorState } = this.state;
-		let newState;
-		switch (command) {
-			case 'insert-soft-newline':
-				newState = RichUtils.insertSoftNewline(editorState);
-				break;
-			default:
-				newState = RichUtils.handleKeyCommand(editorState, command);
-		}
-		if (newState) {
-			this._handleEditorStateChange(newState);
-			return true;
-		}
-		return false;
-	}
-
-	_handlePastedText (text, html) {
-		function insertFragment (editorState, fragment) {
-			let newContent = Modifier.replaceWithFragment(editorState.getCurrentContent(), editorState.getSelection(), fragment);
-			return EditorState.push(editorState, newContent, 'insert-fragment');
+let EntityEditingBlock = (superclass) =>
+	class extends Component {
+		constructor(props) {
+			super(props);
+			this.toggleModal = this._toggleModal.bind(this);
+			this.handleSave = this._handleSave.bind(this);
+			this.composeEditingFields = this._composeEditingFields.bind(this);
+			this.focus = this._focus.bind(this);
+			this._handleEditorStateChange = this._handleEditorStateChange.bind(this);
+			this._handleKeyCommand = this._handleKeyCommand.bind(this);
+			this._handlePastedText = this._handlePastedText.bind(this);
+			this._toggleBlockType = this._toggleBlockStyle.bind(this);
+			this._toggleInlineStyle = this._toggleInlineStyle.bind(this);
+			this._toggleEntity = this._toggleEntity.bind(this);
+			this._editingFields = this.composeEditingFields(props);
+			this.state = {
+				editingFields: this._editingFields,
+				editorState: EditorState.createEmpty(decorator),
+			};
 		}
 
-		if (html) {
-			// remove meta tag
-			html = html.replace(/<meta (.+?)>/g, '');
-			// replace p, h2 by div.
-			// TODO need to find out how many block tags we need to replace
-			// currently, just handle p, h1, h2, ..., h6 tag
-			// NOTE: I don't know why header style can not be parsed into ContentBlock,
-			// so I replace it by div temporarily
-			html = html.replace(/<p|<h1|<h2|<h3|<h4|<h5|<h6/g, '<div').replace(/<\/p|<\/h1|<\/h2|<\/h3|<\/h4|<\/h5|<\/h6/g, '</div');
+		componentWillReceiveProps(nextProps) {
+			this._editingFields = this.composeEditingFields(nextProps);
+			this.setState({
+				editingFields: this._editingFields,
+				editorState: this._initEditorState(nextProps.draftRawObj),
+			});
+		}
 
-			let editorState = this.state.editorState;
-      const htmlFragment = convertFromHTML(html);
-      if (htmlFragment) {
-        const { contentBlocks, entityMap } = htmlFragment;
-        const htmlMap = BlockMapBuilder.createFromArray(contentBlocks);
-				this._handleEditorStateChange(insertFragment(editorState, htmlMap));
-				// prevent the default paste behavior.
+		componentWillUnmount() {
+			this._editingFields = null;
+		}
+
+		_initEditorState(draftRawObj) {
+			let editorState;
+			if (draftRawObj) {
+				let contentState = convertFromRaw(draftRawObj);
+				editorState = EditorState.createWithContent(contentState, decorator);
+			} else {
+				editorState = EditorState.createEmpty(decorator);
+			}
+			return editorState;
+		}
+
+		// need to be overwrited
+		_handleEditorStateChange(editorState) {
+			this.setState({
+				editorState: editorState,
+			});
+		}
+
+		_handleKeyCommand(command) {
+			const { editorState } = this.state;
+			let newState;
+			switch (command) {
+				case 'insert-soft-newline':
+					newState = RichUtils.insertSoftNewline(editorState);
+					break;
+				default:
+					newState = RichUtils.handleKeyCommand(editorState, command);
+			}
+			if (newState) {
+				this._handleEditorStateChange(newState);
 				return true;
 			}
+			return false;
 		}
-		// use default paste behavior
-		return false;
-	}
 
-
-	_keyBindingFn (e) {
-		if (e.keyCode === 13 /* `enter` key */) {
-			if (isCtrlKeyCommand(e) || e.shiftKey) {
-				return 'insert-soft-newline';
+		_handlePastedText(text, html) {
+			function insertFragment(editorState, fragment) {
+				let newContent = Modifier.replaceWithFragment(
+					editorState.getCurrentContent(),
+					editorState.getSelection(),
+					fragment
+				);
+				return EditorState.push(editorState, newContent, 'insert-fragment');
 			}
+
+			if (html) {
+				// remove meta tag
+				html = html.replace(/<meta (.+?)>/g, '');
+				// replace p, h2 by div.
+				// TODO need to find out how many block tags we need to replace
+				// currently, just handle p, h1, h2, ..., h6 tag
+				// NOTE: I don't know why header style can not be parsed into ContentBlock,
+				// so I replace it by div temporarily
+				html = html
+					.replace(/<p|<h1|<h2|<h3|<h4|<h5|<h6/g, '<div')
+					.replace(/<\/p|<\/h1|<\/h2|<\/h3|<\/h4|<\/h5|<\/h6/g, '</div');
+
+				let editorState = this.state.editorState;
+				const htmlFragment = convertFromHTML(html);
+				if (htmlFragment) {
+					const { contentBlocks, entityMap } = htmlFragment;
+					const htmlMap = BlockMapBuilder.createFromArray(contentBlocks);
+					this._handleEditorStateChange(insertFragment(editorState, htmlMap));
+					// prevent the default paste behavior.
+					return true;
+				}
+			}
+			// use default paste behavior
+			return false;
 		}
-		return getDefaultKeyBinding(e);
-	}
 
-	// this function should be overwritten by children
-	_composeEditingFields (props) {
-		console.warn('_composeEditingFields should be extended');
-		return {};
-	}
+		_keyBindingFn(e) {
+			if (e.keyCode === 13 /* `enter` key */) {
+				if (isCtrlKeyCommand(e) || e.shiftKey) {
+					return 'insert-soft-newline';
+				}
+			}
+			return getDefaultKeyBinding(e);
+		}
 
-	// this function should be overwritten by children
-	_decomposeEditingFields (fields) {
-		console.warn('_decomposeEditingFields should be extended');
-		return {};
-	}
+		// this function should be overwritten by children
+		_composeEditingFields(props) {
+			console.warn('_composeEditingFields should be extended');
+			return {};
+		}
 
-	_focus () {
-		this.refs.editor.focus();
-	}
+		// this function should be overwritten by children
+		_decomposeEditingFields(fields) {
+			console.warn('_decomposeEditingFields should be extended');
+			return {};
+		}
 
+		_focus() {
+			this.refs.editor.focus();
+		}
 
-	_handleEditingFieldChange (field, e) {
-		this._editingFields[field].value = e.target.value;
-	}
+		_handleEditingFieldChange(field, e) {
+			this._editingFields[field].value = e.target.value;
+		}
 
-	_handleSave () {
-		this.setState({
-			editingFields: this._editingFields,
-		}, () => {
-			this.props.toggleModal();
-			this.props.onToggle(this._decomposeEditingFields(this._editingFields));
-		});
-	}
+		_handleSave() {
+			this.setState(
+				{
+					editingFields: this._editingFields,
+				},
+				() => {
+					this.props.toggleModal();
+					this.props.onToggle(
+						this._decomposeEditingFields(this._editingFields)
+					);
+				}
+			);
+		}
 
-	_renderDraftjsEditingField (editorState) {
-		return (
-			<div className="RichEditor-root">
-				<div className={'DraftEditor-controls'}>
-					<div className={'DraftEditor-controlsInner'}>
-						<BlockStyleButtons
-							buttons={BLOCK_TYPES}
+		_renderDraftjsEditingField(editorState) {
+			return (
+				<div className="RichEditor-root">
+					<div className={'DraftEditor-controls'}>
+						<div className={'DraftEditor-controlsInner'}>
+							<BlockStyleButtons
+								buttons={BLOCK_TYPES}
+								editorState={editorState}
+								onToggle={this._toggleBlockType}
+							/>
+							<InlineStyleButtons
+								buttons={INLINE_STYLES}
+								editorState={editorState}
+								onToggle={this._toggleInlineStyle}
+							/>
+							<EntityButtons
+								entities={[ENTITY.LINK.type]}
+								editorState={editorState}
+								onToggle={this._toggleEntity}
+							/>
+						</div>
+					</div>
+					<div className={'RichEditor-editor'} onClick={this.focus}>
+						<Editor
+							blockStyleFn={blockStyleFn}
+							handleKeyCommand={this._handleKeyCommand}
+							handlePastedText={this._handlePastedText}
+							keyBindingFn={this._keyBindingFn}
 							editorState={editorState}
-							onToggle={this._toggleBlockType}
-						/>
-						<InlineStyleButtons
-							buttons={INLINE_STYLES}
-							editorState={editorState}
-							onToggle={this._toggleInlineStyle} />
-						<EntityButtons
-							entities={[ENTITY.LINK.type]}
-							editorState={editorState}
-							onToggle={this._toggleEntity}
+							onChange={this._handleEditorStateChange}
+							placeholder="Enter HTML Here..."
+							ref="editor"
+							spellCheck
 						/>
 					</div>
 				</div>
-				<div className={'RichEditor-editor'} onClick={this.focus}>
-					<Editor
-						blockStyleFn={blockStyleFn}
-						handleKeyCommand={this._handleKeyCommand}
-						handlePastedText={this._handlePastedText}
-						keyBindingFn={this._keyBindingFn}
-						editorState={editorState}
-						onChange={this._handleEditorStateChange}
-						placeholder="Enter HTML Here..."
-						ref="editor"
-						spellCheck
-					/>
-				</div>
-			</div>
-		);
-	}
-
-	_renderEditingField (field, type, value) {
-		if (type === 'html') {
-			return this._renderDraftjsEditingField(this.state.editorState);
-		}
-		let onChange = this._handleEditingFieldChange.bind(this, field);
-		return (
-			<FormField label={field} htmlFor={'form-input-' + field} key={field}>
-				<FormInput type={type} multiline={type === 'textarea' ? true : false} placeholder={'Enter ' + field} name={'form-input-' + field} onChange={onChange} defaultValue={value}/>
-			</FormField>
-		);
-	}
-
-	_renderEditingFields (fields) {
-		let Fields = Object.keys(fields).map((field) => {
-			const type = fields[field].type;
-			const value = fields[field].value;
-			return this._renderEditingField(field, type, value);
-		});
-		return Fields;
-	}
-
-	_toggleBlockStyle (blockType) {
-		this._handleEditorStateChange(
-			RichUtils.toggleBlockType(
-				this.state.editorState,
-				blockType
-			)
-		);
-	}
-
-	_toggleEntity (entity, value) {
-		switch (entity) {
-			case ENTITY.LINK.type:
-				return this._toggleLink(entity, value);
-			default:
-				return;
-		}
-	}
-
-	_toggleInlineStyle (inlineStyle) {
-		this._handleEditorStateChange(
-			RichUtils.toggleInlineStyle(
-				this.state.editorState,
-				inlineStyle
-			)
-		);
-	}
-
-	_toggleLink (entity, value) {
-		const { url, text } = value;
-    const { editorState } = this.state;
-    const contentState = editorState.getCurrentContent();
-		const entityKey = url !== '' ? contentState.createEntity(entity, 'IMMUTABLE', { text: text || url, url: url }) : null;
-		this._toggleTextWithEntity(entityKey, text || url);
-	}
-
-	_toggleModal () {
-		this.props.toggleModal();
-	}
-
-	_toggleTextWithEntity (entityKey, text) {
-		const { editorState } = this.state;
-		const selection = editorState.getSelection();
-		let contentState = editorState.getCurrentContent();
-
-		if (selection.isCollapsed()) {
-			contentState = Modifier.removeRange(
-				editorState.getCurrentContent(),
-				selection,
-				'backward'
 			);
 		}
-		contentState = Modifier.replaceText(
-			contentState,
-			selection,
-			text,
-			null,
-			entityKey
-		);
-		const _editorState = EditorState.push(editorState, contentState, editorState.getLastChangeType());
-		this._handleEditorStateChange(_editorState);
-	}
 
+		_renderEditingField(field, type, value) {
+			if (type === 'html') {
+				return this._renderDraftjsEditingField(this.state.editorState);
+			}
+			let onChange = this._handleEditingFieldChange.bind(this, field);
+			return (
+				<FormField label={field} htmlFor={'form-input-' + field} key={field}>
+					<FormInput
+						type={type}
+						multiline={type === 'textarea' ? true : false}
+						placeholder={'Enter ' + field}
+						name={'form-input-' + field}
+						onChange={onChange}
+						defaultValue={value}
+					/>
+				</FormField>
+			);
+		}
 
-	render () {
-		return (
-			<Modal isOpen={this.props.isModalOpen} onCancel={this.toggleModal} backdropClosesModal>
-				<Modal.Header text={'Insert ' + this.props.label} showCloseButton onClose={this.toggleModal} />
-				<Modal.Body>
-					{this._renderEditingFields(this.state.editingFields)}
-				</Modal.Body>
-				<Modal.Footer>
-					<Button type="primary" onClick={this.handleSave}>Save</Button>
-					<Button type="link-cancel" onClick={this.toggleModal}>Cancel</Button>
-				</Modal.Footer>
-			</Modal>
-		);
-	}
-};
+		_renderEditingFields(fields) {
+			let Fields = Object.keys(fields).map((field) => {
+				const type = fields[field].type;
+				const value = fields[field].value;
+				return this._renderEditingField(field, type, value);
+			});
+			return Fields;
+		}
+
+		_toggleBlockStyle(blockType) {
+			this._handleEditorStateChange(
+				RichUtils.toggleBlockType(this.state.editorState, blockType)
+			);
+		}
+
+		_toggleEntity(entity, value) {
+			switch (entity) {
+				case ENTITY.LINK.type:
+					return this._toggleLink(entity, value);
+				default:
+					return;
+			}
+		}
+
+		_toggleInlineStyle(inlineStyle) {
+			this._handleEditorStateChange(
+				RichUtils.toggleInlineStyle(this.state.editorState, inlineStyle)
+			);
+		}
+
+		_toggleLink(entity, value) {
+			const { url, text } = value;
+			const { editorState } = this.state;
+			const contentState = editorState.getCurrentContent();
+			const entityKey =
+				url !== ''
+					? contentState.createEntity(entity, 'IMMUTABLE', {
+							text: text || url,
+							url: url,
+					  })
+					: null;
+			this._toggleTextWithEntity(entityKey, text || url);
+		}
+
+		_toggleModal() {
+			this.props.toggleModal();
+		}
+
+		_toggleTextWithEntity(entityKey, text) {
+			const { editorState } = this.state;
+			const selection = editorState.getSelection();
+			let contentState = editorState.getCurrentContent();
+
+			if (selection.isCollapsed()) {
+				contentState = Modifier.removeRange(
+					editorState.getCurrentContent(),
+					selection,
+					'backward'
+				);
+			}
+			contentState = Modifier.replaceText(
+				contentState,
+				selection,
+				text,
+				null,
+				entityKey
+			);
+			const _editorState = EditorState.push(
+				editorState,
+				contentState,
+				editorState.getLastChangeType()
+			);
+			this._handleEditorStateChange(_editorState);
+		}
+
+		render() {
+			return (
+				<Modal
+					isOpen={this.props.isModalOpen}
+					onCancel={this.toggleModal}
+					backdropClosesModal
+				>
+					<Modal.Header
+						text={'Insert ' + this.props.label}
+						showCloseButton
+						onClose={this.toggleModal}
+					/>
+					<Modal.Body>
+						{this._renderEditingFields(this.state.editingFields)}
+					</Modal.Body>
+					<Modal.Footer>
+						<Button type="primary" onClick={this.handleSave}>
+							Save
+						</Button>
+						<Button type="link-cancel" onClick={this.toggleModal}>
+							Cancel
+						</Button>
+					</Modal.Footer>
+				</Modal>
+			);
+		}
+	};
 
 // block settings
 const BLOCK_TYPES = [
@@ -297,6 +344,5 @@ var INLINE_STYLES = [
 	{ label: 'Italic', style: 'ITALIC', icon: 'fa-italic', text: '' },
 	{ label: 'Underline', style: 'UNDERLINE', icon: 'fa-underline', text: '' },
 ];
-
 
 export default EntityEditingBlock;

--- a/fields/types/html/editor/mixins/entity-editing-block-mixin.js
+++ b/fields/types/html/editor/mixins/entity-editing-block-mixin.js
@@ -1,6 +1,6 @@
 'use strict';
 import { Button, FormField, FormInput, Modal } from 'elemental';
-import { BlockMapBuilder, Editor, EditorState, KeyBindingUtil, Modifier, RichUtils, convertFromHTML, convertFromRaw, getDefaultKeyBinding } from 'draft-js';
+import { BlockMapBuilder, Editor, EditorState, KeyBindingUtil, Modifier, RichUtils, convertFromHTML, convertFromRaw, getDefaultKeyBinding } from '@twreporter/draft-js';
 import { BlockStyleButtons, EntityButtons, InlineStyleButtons } from '../editor-buttons';
 import ENTITY from '../entities';
 import React, { Component } from 'react';

--- a/fields/types/html/editor/mixins/entity-editing-block-mixin.js
+++ b/fields/types/html/editor/mixins/entity-editing-block-mixin.js
@@ -1,20 +1,20 @@
 'use strict';
 import { Button, FormField, FormInput, Modal } from 'elemental';
 import {
-	BlockMapBuilder,
-	Editor,
-	EditorState,
-	KeyBindingUtil,
-	Modifier,
-	RichUtils,
-	convertFromHTML,
-	convertFromRaw,
-	getDefaultKeyBinding,
+  BlockMapBuilder,
+  Editor,
+  EditorState,
+  KeyBindingUtil,
+  Modifier,
+  RichUtils,
+  convertFromHTML,
+  convertFromRaw,
+  getDefaultKeyBinding,
 } from '@twreporter/draft-js';
 import {
-	BlockStyleButtons,
-	EntityButtons,
-	InlineStyleButtons,
+  BlockStyleButtons,
+  EntityButtons,
+  InlineStyleButtons,
 } from '../editor-buttons';
 import ENTITY from '../entities';
 import React, { Component } from 'react';
@@ -24,325 +24,325 @@ import decorator from '../entity-decorator';
 const { isCtrlKeyCommand } = KeyBindingUtil;
 
 let EntityEditingBlock = (superclass) =>
-	class extends Component {
-		constructor(props) {
-			super(props);
-			this.toggleModal = this._toggleModal.bind(this);
-			this.handleSave = this._handleSave.bind(this);
-			this.composeEditingFields = this._composeEditingFields.bind(this);
-			this.focus = this._focus.bind(this);
-			this._handleEditorStateChange = this._handleEditorStateChange.bind(this);
-			this._handleKeyCommand = this._handleKeyCommand.bind(this);
-			this._handlePastedText = this._handlePastedText.bind(this);
-			this._toggleBlockType = this._toggleBlockStyle.bind(this);
-			this._toggleInlineStyle = this._toggleInlineStyle.bind(this);
-			this._toggleEntity = this._toggleEntity.bind(this);
-			this._editingFields = this.composeEditingFields(props);
-			this.state = {
-				editingFields: this._editingFields,
-				editorState: EditorState.createEmpty(decorator),
-			};
-		}
+  class extends Component {
+    constructor(props) {
+      super(props);
+      this.toggleModal = this._toggleModal.bind(this);
+      this.handleSave = this._handleSave.bind(this);
+      this.composeEditingFields = this._composeEditingFields.bind(this);
+      this.focus = this._focus.bind(this);
+      this._handleEditorStateChange = this._handleEditorStateChange.bind(this);
+      this._handleKeyCommand = this._handleKeyCommand.bind(this);
+      this._handlePastedText = this._handlePastedText.bind(this);
+      this._toggleBlockType = this._toggleBlockStyle.bind(this);
+      this._toggleInlineStyle = this._toggleInlineStyle.bind(this);
+      this._toggleEntity = this._toggleEntity.bind(this);
+      this._editingFields = this.composeEditingFields(props);
+      this.state = {
+        editingFields: this._editingFields,
+        editorState: EditorState.createEmpty(decorator),
+      };
+    }
 
-		componentWillReceiveProps(nextProps) {
-			this._editingFields = this.composeEditingFields(nextProps);
-			this.setState({
-				editingFields: this._editingFields,
-				editorState: this._initEditorState(nextProps.draftRawObj),
-			});
-		}
+    componentWillReceiveProps(nextProps) {
+      this._editingFields = this.composeEditingFields(nextProps);
+      this.setState({
+        editingFields: this._editingFields,
+        editorState: this._initEditorState(nextProps.draftRawObj),
+      });
+    }
 
-		componentWillUnmount() {
-			this._editingFields = null;
-		}
+    componentWillUnmount() {
+      this._editingFields = null;
+    }
 
-		_initEditorState(draftRawObj) {
-			let editorState;
-			if (draftRawObj) {
-				let contentState = convertFromRaw(draftRawObj);
-				editorState = EditorState.createWithContent(contentState, decorator);
-			} else {
-				editorState = EditorState.createEmpty(decorator);
-			}
-			return editorState;
-		}
+    _initEditorState(draftRawObj) {
+      let editorState;
+      if (draftRawObj) {
+        let contentState = convertFromRaw(draftRawObj);
+        editorState = EditorState.createWithContent(contentState, decorator);
+      } else {
+        editorState = EditorState.createEmpty(decorator);
+      }
+      return editorState;
+    }
 
-		// need to be overwrited
-		_handleEditorStateChange(editorState) {
-			this.setState({
-				editorState: editorState,
-			});
-		}
+    // need to be overwrited
+    _handleEditorStateChange(editorState) {
+      this.setState({
+        editorState: editorState,
+      });
+    }
 
-		_handleKeyCommand(command) {
-			const { editorState } = this.state;
-			let newState;
-			switch (command) {
-				case 'insert-soft-newline':
-					newState = RichUtils.insertSoftNewline(editorState);
-					break;
-				default:
-					newState = RichUtils.handleKeyCommand(editorState, command);
-			}
-			if (newState) {
-				this._handleEditorStateChange(newState);
-				return true;
-			}
-			return false;
-		}
+    _handleKeyCommand(command) {
+      const { editorState } = this.state;
+      let newState;
+      switch (command) {
+        case 'insert-soft-newline':
+          newState = RichUtils.insertSoftNewline(editorState);
+          break;
+        default:
+          newState = RichUtils.handleKeyCommand(editorState, command);
+      }
+      if (newState) {
+        this._handleEditorStateChange(newState);
+        return true;
+      }
+      return false;
+    }
 
-		_handlePastedText(text, html) {
-			function insertFragment(editorState, fragment) {
-				let newContent = Modifier.replaceWithFragment(
-					editorState.getCurrentContent(),
-					editorState.getSelection(),
-					fragment
-				);
-				return EditorState.push(editorState, newContent, 'insert-fragment');
-			}
+    _handlePastedText(text, html) {
+      function insertFragment(editorState, fragment) {
+        let newContent = Modifier.replaceWithFragment(
+          editorState.getCurrentContent(),
+          editorState.getSelection(),
+          fragment
+        );
+        return EditorState.push(editorState, newContent, 'insert-fragment');
+      }
 
-			if (html) {
-				// remove meta tag
-				html = html.replace(/<meta (.+?)>/g, '');
-				// replace p, h2 by div.
-				// TODO need to find out how many block tags we need to replace
-				// currently, just handle p, h1, h2, ..., h6 tag
-				// NOTE: I don't know why header style can not be parsed into ContentBlock,
-				// so I replace it by div temporarily
-				html = html
-					.replace(/<p|<h1|<h2|<h3|<h4|<h5|<h6/g, '<div')
-					.replace(/<\/p|<\/h1|<\/h2|<\/h3|<\/h4|<\/h5|<\/h6/g, '</div');
+      if (html) {
+        // remove meta tag
+        html = html.replace(/<meta (.+?)>/g, '');
+        // replace p, h2 by div.
+        // TODO need to find out how many block tags we need to replace
+        // currently, just handle p, h1, h2, ..., h6 tag
+        // NOTE: I don't know why header style can not be parsed into ContentBlock,
+        // so I replace it by div temporarily
+        html = html
+          .replace(/<p|<h1|<h2|<h3|<h4|<h5|<h6/g, '<div')
+          .replace(/<\/p|<\/h1|<\/h2|<\/h3|<\/h4|<\/h5|<\/h6/g, '</div');
 
-				let editorState = this.state.editorState;
-				const htmlFragment = convertFromHTML(html);
-				if (htmlFragment) {
-					const { contentBlocks, entityMap } = htmlFragment;
-					const htmlMap = BlockMapBuilder.createFromArray(contentBlocks);
-					this._handleEditorStateChange(insertFragment(editorState, htmlMap));
-					// prevent the default paste behavior.
-					return true;
-				}
-			}
-			// use default paste behavior
-			return false;
-		}
+        let editorState = this.state.editorState;
+        const htmlFragment = convertFromHTML(html);
+        if (htmlFragment) {
+          const { contentBlocks, entityMap } = htmlFragment;
+          const htmlMap = BlockMapBuilder.createFromArray(contentBlocks);
+          this._handleEditorStateChange(insertFragment(editorState, htmlMap));
+          // prevent the default paste behavior.
+          return true;
+        }
+      }
+      // use default paste behavior
+      return false;
+    }
 
-		_keyBindingFn(e) {
-			if (e.keyCode === 13 /* `enter` key */) {
-				if (isCtrlKeyCommand(e) || e.shiftKey) {
-					return 'insert-soft-newline';
-				}
-			}
-			return getDefaultKeyBinding(e);
-		}
+    _keyBindingFn(e) {
+      if (e.keyCode === 13 /* `enter` key */) {
+        if (isCtrlKeyCommand(e) || e.shiftKey) {
+          return 'insert-soft-newline';
+        }
+      }
+      return getDefaultKeyBinding(e);
+    }
 
-		// this function should be overwritten by children
-		_composeEditingFields(props) {
-			console.warn('_composeEditingFields should be extended');
-			return {};
-		}
+    // this function should be overwritten by children
+    _composeEditingFields(props) {
+      console.warn('_composeEditingFields should be extended');
+      return {};
+    }
 
-		// this function should be overwritten by children
-		_decomposeEditingFields(fields) {
-			console.warn('_decomposeEditingFields should be extended');
-			return {};
-		}
+    // this function should be overwritten by children
+    _decomposeEditingFields(fields) {
+      console.warn('_decomposeEditingFields should be extended');
+      return {};
+    }
 
-		_focus() {
-			this.refs.editor.focus();
-		}
+    _focus() {
+      this.refs.editor.focus();
+    }
 
-		_handleEditingFieldChange(field, e) {
-			this._editingFields[field].value = e.target.value;
-		}
+    _handleEditingFieldChange(field, e) {
+      this._editingFields[field].value = e.target.value;
+    }
 
-		_handleSave() {
-			this.setState(
-				{
-					editingFields: this._editingFields,
-				},
-				() => {
-					this.props.toggleModal();
-					this.props.onToggle(
-						this._decomposeEditingFields(this._editingFields)
-					);
-				}
-			);
-		}
+    _handleSave() {
+      this.setState(
+        {
+          editingFields: this._editingFields,
+        },
+        () => {
+          this.props.toggleModal();
+          this.props.onToggle(
+            this._decomposeEditingFields(this._editingFields)
+          );
+        }
+      );
+    }
 
-		_renderDraftjsEditingField(editorState) {
-			return (
-				<div className="RichEditor-root">
-					<div className={'DraftEditor-controls'}>
-						<div className={'DraftEditor-controlsInner'}>
-							<BlockStyleButtons
-								buttons={BLOCK_TYPES}
-								editorState={editorState}
-								onToggle={this._toggleBlockType}
-							/>
-							<InlineStyleButtons
-								buttons={INLINE_STYLES}
-								editorState={editorState}
-								onToggle={this._toggleInlineStyle}
-							/>
-							<EntityButtons
-								entities={[ENTITY.LINK.type]}
-								editorState={editorState}
-								onToggle={this._toggleEntity}
-							/>
-						</div>
-					</div>
-					<div className={'RichEditor-editor'} onClick={this.focus}>
-						<Editor
-							blockStyleFn={blockStyleFn}
-							handleKeyCommand={this._handleKeyCommand}
-							handlePastedText={this._handlePastedText}
-							keyBindingFn={this._keyBindingFn}
-							editorState={editorState}
-							onChange={this._handleEditorStateChange}
-							placeholder="Enter HTML Here..."
-							ref="editor"
-							spellCheck
-						/>
-					</div>
-				</div>
-			);
-		}
+    _renderDraftjsEditingField(editorState) {
+      return (
+        <div className="RichEditor-root">
+          <div className={'DraftEditor-controls'}>
+            <div className={'DraftEditor-controlsInner'}>
+              <BlockStyleButtons
+                buttons={BLOCK_TYPES}
+                editorState={editorState}
+                onToggle={this._toggleBlockType}
+              />
+              <InlineStyleButtons
+                buttons={INLINE_STYLES}
+                editorState={editorState}
+                onToggle={this._toggleInlineStyle}
+              />
+              <EntityButtons
+                entities={[ENTITY.LINK.type]}
+                editorState={editorState}
+                onToggle={this._toggleEntity}
+              />
+            </div>
+          </div>
+          <div className={'RichEditor-editor'} onClick={this.focus}>
+            <Editor
+              blockStyleFn={blockStyleFn}
+              handleKeyCommand={this._handleKeyCommand}
+              handlePastedText={this._handlePastedText}
+              keyBindingFn={this._keyBindingFn}
+              editorState={editorState}
+              onChange={this._handleEditorStateChange}
+              placeholder="Enter HTML Here..."
+              ref="editor"
+              spellCheck
+            />
+          </div>
+        </div>
+      );
+    }
 
-		_renderEditingField(field, type, value) {
-			if (type === 'html') {
-				return this._renderDraftjsEditingField(this.state.editorState);
-			}
-			let onChange = this._handleEditingFieldChange.bind(this, field);
-			return (
-				<FormField label={field} htmlFor={'form-input-' + field} key={field}>
-					<FormInput
-						type={type}
-						multiline={type === 'textarea' ? true : false}
-						placeholder={'Enter ' + field}
-						name={'form-input-' + field}
-						onChange={onChange}
-						defaultValue={value}
-					/>
-				</FormField>
-			);
-		}
+    _renderEditingField(field, type, value) {
+      if (type === 'html') {
+        return this._renderDraftjsEditingField(this.state.editorState);
+      }
+      let onChange = this._handleEditingFieldChange.bind(this, field);
+      return (
+        <FormField label={field} htmlFor={'form-input-' + field} key={field}>
+          <FormInput
+            type={type}
+            multiline={type === 'textarea' ? true : false}
+            placeholder={'Enter ' + field}
+            name={'form-input-' + field}
+            onChange={onChange}
+            defaultValue={value}
+          />
+        </FormField>
+      );
+    }
 
-		_renderEditingFields(fields) {
-			let Fields = Object.keys(fields).map((field) => {
-				const type = fields[field].type;
-				const value = fields[field].value;
-				return this._renderEditingField(field, type, value);
-			});
-			return Fields;
-		}
+    _renderEditingFields(fields) {
+      let Fields = Object.keys(fields).map((field) => {
+        const type = fields[field].type;
+        const value = fields[field].value;
+        return this._renderEditingField(field, type, value);
+      });
+      return Fields;
+    }
 
-		_toggleBlockStyle(blockType) {
-			this._handleEditorStateChange(
-				RichUtils.toggleBlockType(this.state.editorState, blockType)
-			);
-		}
+    _toggleBlockStyle(blockType) {
+      this._handleEditorStateChange(
+        RichUtils.toggleBlockType(this.state.editorState, blockType)
+      );
+    }
 
-		_toggleEntity(entity, value) {
-			switch (entity) {
-				case ENTITY.LINK.type:
-					return this._toggleLink(entity, value);
-				default:
-					return;
-			}
-		}
+    _toggleEntity(entity, value) {
+      switch (entity) {
+        case ENTITY.LINK.type:
+          return this._toggleLink(entity, value);
+        default:
+          return;
+      }
+    }
 
-		_toggleInlineStyle(inlineStyle) {
-			this._handleEditorStateChange(
-				RichUtils.toggleInlineStyle(this.state.editorState, inlineStyle)
-			);
-		}
+    _toggleInlineStyle(inlineStyle) {
+      this._handleEditorStateChange(
+        RichUtils.toggleInlineStyle(this.state.editorState, inlineStyle)
+      );
+    }
 
-		_toggleLink(entity, value) {
-			const { url, text } = value;
-			const { editorState } = this.state;
-			const contentState = editorState.getCurrentContent();
-			const entityKey =
-				url !== ''
-					? contentState.createEntity(entity, 'IMMUTABLE', {
-							text: text || url,
-							url: url,
-					  })
-					: null;
-			this._toggleTextWithEntity(entityKey, text || url);
-		}
+    _toggleLink(entity, value) {
+      const { url, text } = value;
+      const { editorState } = this.state;
+      const contentState = editorState.getCurrentContent();
+      const entityKey =
+        url !== ''
+          ? contentState.createEntity(entity, 'IMMUTABLE', {
+              text: text || url,
+              url: url,
+            })
+          : null;
+      this._toggleTextWithEntity(entityKey, text || url);
+    }
 
-		_toggleModal() {
-			this.props.toggleModal();
-		}
+    _toggleModal() {
+      this.props.toggleModal();
+    }
 
-		_toggleTextWithEntity(entityKey, text) {
-			const { editorState } = this.state;
-			const selection = editorState.getSelection();
-			let contentState = editorState.getCurrentContent();
+    _toggleTextWithEntity(entityKey, text) {
+      const { editorState } = this.state;
+      const selection = editorState.getSelection();
+      let contentState = editorState.getCurrentContent();
 
-			if (selection.isCollapsed()) {
-				contentState = Modifier.removeRange(
-					editorState.getCurrentContent(),
-					selection,
-					'backward'
-				);
-			}
-			contentState = Modifier.replaceText(
-				contentState,
-				selection,
-				text,
-				null,
-				entityKey
-			);
-			const _editorState = EditorState.push(
-				editorState,
-				contentState,
-				editorState.getLastChangeType()
-			);
-			this._handleEditorStateChange(_editorState);
-		}
+      if (selection.isCollapsed()) {
+        contentState = Modifier.removeRange(
+          editorState.getCurrentContent(),
+          selection,
+          'backward'
+        );
+      }
+      contentState = Modifier.replaceText(
+        contentState,
+        selection,
+        text,
+        null,
+        entityKey
+      );
+      const _editorState = EditorState.push(
+        editorState,
+        contentState,
+        editorState.getLastChangeType()
+      );
+      this._handleEditorStateChange(_editorState);
+    }
 
-		render() {
-			return (
-				<Modal
-					isOpen={this.props.isModalOpen}
-					onCancel={this.toggleModal}
-					backdropClosesModal
-				>
-					<Modal.Header
-						text={'Insert ' + this.props.label}
-						showCloseButton
-						onClose={this.toggleModal}
-					/>
-					<Modal.Body>
-						{this._renderEditingFields(this.state.editingFields)}
-					</Modal.Body>
-					<Modal.Footer>
-						<Button type="primary" onClick={this.handleSave}>
-							Save
-						</Button>
-						<Button type="link-cancel" onClick={this.toggleModal}>
-							Cancel
-						</Button>
-					</Modal.Footer>
-				</Modal>
-			);
-		}
-	};
+    render() {
+      return (
+        <Modal
+          isOpen={this.props.isModalOpen}
+          onCancel={this.toggleModal}
+          backdropClosesModal
+        >
+          <Modal.Header
+            text={'Insert ' + this.props.label}
+            showCloseButton
+            onClose={this.toggleModal}
+          />
+          <Modal.Body>
+            {this._renderEditingFields(this.state.editingFields)}
+          </Modal.Body>
+          <Modal.Footer>
+            <Button type="primary" onClick={this.handleSave}>
+              Save
+            </Button>
+            <Button type="link-cancel" onClick={this.toggleModal}>
+              Cancel
+            </Button>
+          </Modal.Footer>
+        </Modal>
+      );
+    }
+  };
 
 // block settings
 const BLOCK_TYPES = [
-	{ label: 'H2', style: 'header-two', icon: 'fa-header', text: '2' },
-	{ label: 'OL', style: 'ordered-list-item', icon: 'fa-list-ol', text: '' },
-	{ label: 'UL', style: 'unordered-list-item', icon: 'fa-list-ul', text: '' },
+  { label: 'H2', style: 'header-two', icon: 'fa-header', text: '2' },
+  { label: 'OL', style: 'ordered-list-item', icon: 'fa-list-ol', text: '' },
+  { label: 'UL', style: 'unordered-list-item', icon: 'fa-list-ul', text: '' },
 ];
 
 // inline style settings
 var INLINE_STYLES = [
-	{ label: 'Bold', style: 'BOLD', icon: 'fa-bold', text: '' },
-	{ label: 'Italic', style: 'ITALIC', icon: 'fa-italic', text: '' },
-	{ label: 'Underline', style: 'UNDERLINE', icon: 'fa-underline', text: '' },
+  { label: 'Bold', style: 'BOLD', icon: 'fa-bold', text: '' },
+  { label: 'Italic', style: 'ITALIC', icon: 'fa-italic', text: '' },
+  { label: 'Underline', style: 'UNDERLINE', icon: 'fa-underline', text: '' },
 ];
 
 export default EntityEditingBlock;

--- a/fields/types/html/editor/mixins/entity-editing-block-mixin.js
+++ b/fields/types/html/editor/mixins/entity-editing-block-mixin.js
@@ -1,6 +1,6 @@
 'use strict';
 import { Button, FormField, FormInput, Modal } from 'elemental';
-import { BlockMapBuilder, Editor, EditorState, Entity, KeyBindingUtil, Modifier, RichUtils, convertFromHTML, convertFromRaw, getDefaultKeyBinding } from 'draft-js';
+import { BlockMapBuilder, Editor, EditorState, KeyBindingUtil, Modifier, RichUtils, convertFromHTML, convertFromRaw, getDefaultKeyBinding } from 'draft-js';
 import { BlockStyleButtons, EntityButtons, InlineStyleButtons } from '../editor-buttons';
 import ENTITY from '../entities';
 import React, { Component } from 'react';
@@ -94,8 +94,8 @@ let EntityEditingBlock = (superclass) => class extends Component {
 
 			let editorState = this.state.editorState;
 			var htmlFragment = convertFromHTML(html);
-			if (htmlFragment) {
-				var htmlMap = BlockMapBuilder.createFromArray(htmlFragment);
+      if (htmlFragment) {
+        var htmlMap = BlockMapBuilder.createFromArray(htmlFragment);
 				this._handleEditorStateChange(insertFragment(editorState, htmlMap));
 				// prevent the default paste behavior.
 				return true;
@@ -233,7 +233,9 @@ let EntityEditingBlock = (superclass) => class extends Component {
 
 	_toggleLink (entity, value) {
 		const { url, text } = value;
-		const entityKey = url !== '' ? Entity.create(entity, 'IMMUTABLE', { text: text || url, url: url }) : null;
+    const { editorState } = this.state;
+    const contentState = editorState.getCurrentContent();
+		const entityKey = url !== '' ? contentState.createEntity(entity, 'IMMUTABLE', { text: text || url, url: url }) : null;
 		this._toggleTextWithEntity(entityKey, text || url);
 	}
 

--- a/fields/types/html/editor/modifiers/index.js
+++ b/fields/types/html/editor/modifiers/index.js
@@ -2,15 +2,15 @@
 
 import insertAtomicBlock from './insert-atomic-block';
 import { replaceAtomicBlock } from './replace-block';
-import { Entity } from 'draft-js';
 import removeBlock from './remove-block';
 
 const handleAtomicEdit = (editorState, blockKey, valueChanged) => {
-	const block = editorState.getCurrentContent().getBlockForKey(blockKey);
+  const contentState = editorState.getCurrentContent() 
+	const block = contentState.getBlockForKey(blockKey);
 	const entityKey = block.getEntityAt(0);
 	let blockType;
-	try {
-		blockType = entityKey ? Entity.get(entityKey).getType() : '';
+  try {
+		blockType = entityKey ? contentState.getEntity(entityKey).getType() : '';
 	} catch (e) {
 		console.log('Get entity type in the block occurs error ', e);
 		return editorState;

--- a/fields/types/html/editor/modifiers/index.js
+++ b/fields/types/html/editor/modifiers/index.js
@@ -5,27 +5,27 @@ import { replaceAtomicBlock } from './replace-block';
 import removeBlock from './remove-block';
 
 const handleAtomicEdit = (editorState, blockKey, valueChanged) => {
-	const contentState = editorState.getCurrentContent();
-	const block = contentState.getBlockForKey(blockKey);
-	const entityKey = block.getEntityAt(0);
-	let blockType;
-	try {
-		blockType = entityKey ? contentState.getEntity(entityKey).getType() : '';
-	} catch (e) {
-		console.log('Get entity type in the block occurs error ', e);
-		return editorState;
-	}
+  const contentState = editorState.getCurrentContent();
+  const block = contentState.getBlockForKey(blockKey);
+  const entityKey = block.getEntityAt(0);
+  let blockType;
+  try {
+    blockType = entityKey ? contentState.getEntity(entityKey).getType() : '';
+  } catch (e) {
+    console.log('Get entity type in the block occurs error ', e);
+    return editorState;
+  }
 
-	// backward compatible. Old block type is lower case
-	blockType = blockType && blockType.toUpperCase();
+  // backward compatible. Old block type is lower case
+  blockType = blockType && blockType.toUpperCase();
 
-	if (valueChanged) {
-		return replaceAtomicBlock(editorState, blockKey, valueChanged);
-	}
-	return removeBlock(editorState, blockKey);
+  if (valueChanged) {
+    return replaceAtomicBlock(editorState, blockKey, valueChanged);
+  }
+  return removeBlock(editorState, blockKey);
 };
 
 export default {
-	insertAtomicBlock,
-	handleAtomicEdit,
+  insertAtomicBlock,
+  handleAtomicEdit,
 };

--- a/fields/types/html/editor/modifiers/index.js
+++ b/fields/types/html/editor/modifiers/index.js
@@ -5,11 +5,11 @@ import { replaceAtomicBlock } from './replace-block';
 import removeBlock from './remove-block';
 
 const handleAtomicEdit = (editorState, blockKey, valueChanged) => {
-  const contentState = editorState.getCurrentContent() 
+	const contentState = editorState.getCurrentContent();
 	const block = contentState.getBlockForKey(blockKey);
 	const entityKey = block.getEntityAt(0);
 	let blockType;
-  try {
+	try {
 		blockType = entityKey ? contentState.getEntity(entityKey).getType() : '';
 	} catch (e) {
 		console.log('Get entity type in the block occurs error ', e);

--- a/fields/types/html/editor/modifiers/insert-atomic-block.js
+++ b/fields/types/html/editor/modifiers/insert-atomic-block.js
@@ -2,7 +2,7 @@
 
 import {
   AtomicBlockUtils,
-} from 'draft-js';
+} from '@twreporter/draft-js';
 
 export default function insertAtomicBlock (editorState, type, value) {
   const contentState = editorState.getCurrentContent();

--- a/fields/types/html/editor/modifiers/insert-atomic-block.js
+++ b/fields/types/html/editor/modifiers/insert-atomic-block.js
@@ -3,13 +3,13 @@
 import { AtomicBlockUtils } from '@twreporter/draft-js';
 
 export default function insertAtomicBlock(editorState, type, value) {
-	const contentState = editorState.getCurrentContent();
-	const contentStateWithEntity = contentState.createEntity(
-		type,
-		'IMMUTABLE',
-		value
-	);
-	const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
+  const contentState = editorState.getCurrentContent();
+  const contentStateWithEntity = contentState.createEntity(
+    type,
+    'IMMUTABLE',
+    value
+  );
+  const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
 
-	return AtomicBlockUtils.insertAtomicBlock(editorState, entityKey, ' ');
+  return AtomicBlockUtils.insertAtomicBlock(editorState, entityKey, ' ');
 }

--- a/fields/types/html/editor/modifiers/insert-atomic-block.js
+++ b/fields/types/html/editor/modifiers/insert-atomic-block.js
@@ -1,16 +1,13 @@
 'use strict';
 
 import {
-	AtomicBlockUtils,
-	Entity,
+  AtomicBlockUtils,
 } from 'draft-js';
 
 export default function insertAtomicBlock (editorState, type, value) {
-	const entityKey = Entity.create(
-		type,
-		'IMMUTABLE',
-		value
-	);
+  const contentState = editorState.getCurrentContent();
+  const contentStateWithEntity = contentState.createEntity(type, 'IMMUTABLE', value);
+  const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
 
 	return AtomicBlockUtils.insertAtomicBlock(editorState, entityKey, ' ');
 }

--- a/fields/types/html/editor/modifiers/insert-atomic-block.js
+++ b/fields/types/html/editor/modifiers/insert-atomic-block.js
@@ -1,13 +1,15 @@
 'use strict';
 
-import {
-  AtomicBlockUtils,
-} from '@twreporter/draft-js';
+import { AtomicBlockUtils } from '@twreporter/draft-js';
 
-export default function insertAtomicBlock (editorState, type, value) {
-  const contentState = editorState.getCurrentContent();
-  const contentStateWithEntity = contentState.createEntity(type, 'IMMUTABLE', value);
-  const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
+export default function insertAtomicBlock(editorState, type, value) {
+	const contentState = editorState.getCurrentContent();
+	const contentStateWithEntity = contentState.createEntity(
+		type,
+		'IMMUTABLE',
+		value
+	);
+	const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
 
 	return AtomicBlockUtils.insertAtomicBlock(editorState, entityKey, ' ');
 }

--- a/fields/types/html/editor/modifiers/remove-block.js
+++ b/fields/types/html/editor/modifiers/remove-block.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { EditorState, Modifier, SelectionState } from 'draft-js';
+import { EditorState, Modifier, SelectionState } from '@twreporter/draft-js';
 
 export default (editorState, blockKey) => {
 	var content = editorState.getCurrentContent();

--- a/fields/types/html/editor/modifiers/replace-block.js
+++ b/fields/types/html/editor/modifiers/replace-block.js
@@ -1,11 +1,9 @@
 'use strict';
 
-import { Entity } from 'draft-js';
-
 export function replaceAtomicBlock (editorState, blockKey, value) {
-	const content = editorState.getCurrentContent();
-	const block = content.getBlockForKey(blockKey);
+	const contentState = editorState.getCurrentContent();
+	const block = contentState.getBlockForKey(blockKey);
 	const entityKey = block.getEntityAt(0);
-	Entity.replaceData(entityKey, value);
+  contentState.replaceEntityData(entityKey, value);
 	return editorState;
 };

--- a/fields/types/html/editor/modifiers/replace-block.js
+++ b/fields/types/html/editor/modifiers/replace-block.js
@@ -1,9 +1,9 @@
 'use strict';
 
-export function replaceAtomicBlock (editorState, blockKey, value) {
+export function replaceAtomicBlock(editorState, blockKey, value) {
 	const contentState = editorState.getCurrentContent();
 	const block = contentState.getBlockForKey(blockKey);
 	const entityKey = block.getEntityAt(0);
-  contentState.replaceEntityData(entityKey, value);
+	contentState.replaceEntityData(entityKey, value);
 	return editorState;
-};
+}

--- a/fields/types/html/editor/modifiers/replace-block.js
+++ b/fields/types/html/editor/modifiers/replace-block.js
@@ -1,9 +1,9 @@
 'use strict';
 
 export function replaceAtomicBlock(editorState, blockKey, value) {
-	const contentState = editorState.getCurrentContent();
-	const block = contentState.getBlockForKey(blockKey);
-	const entityKey = block.getEntityAt(0);
-	contentState.replaceEntityData(entityKey, value);
-	return editorState;
+  const contentState = editorState.getCurrentContent();
+  const block = contentState.getBlockForKey(blockKey);
+  const entityKey = block.getEntityAt(0);
+  contentState.replaceEntityData(entityKey, value);
+  return editorState;
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@google-cloud/storage": "~1.7.0",
+    "@twreporter/draft-js": "0.11.8-rc.0",
     "@twreporter/react-article-components": "0.2.0",
     "async": "1.5.2",
     "asyncdi": "1.1.0",
@@ -38,7 +39,6 @@
     "core-assert": "0.1.3",
     "debug": "2.2.0",
     "display-name": "0.1.0",
-    "draft-js": "^0.8.0",
     "elemental": "^0.6.0",
     "embedly": "1.0.4",
     "errorhandler": "1.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -241,6 +241,15 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@twreporter/draft-js@0.11.8-rc.0":
+  version "0.11.8-rc.0"
+  resolved "https://registry.yarnpkg.com/@twreporter/draft-js/-/draft-js-0.11.8-rc.0.tgz#a5ee3afcee0e03607f12f7c6363b805c09fbd24a"
+  integrity sha512-PbHCb0lVr+i5yJC7Nan2KyK2uuEN67pLC40C0toBir7s2No4rnjo7hgNrOlNpBRvw2kzyf/1ltafDX2WPINTpA==
+  dependencies:
+    fbjs "^2.0.0"
+    immutable "~3.7.4"
+    object-assign "^4.1.1"
+
 "@twreporter/react-article-components@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@twreporter/react-article-components/-/react-article-components-0.2.0.tgz#d47356bda24b5713707ac2a7b1923bd4e65d5570"
@@ -2873,6 +2882,11 @@ core-js@^2.5.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.10.tgz#8a5b8391f8cc7013da703411ce5b585706300d7f"
   integrity sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==
 
+core-js@^3.6.4:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.14.0.tgz#62322b98c71cc2018b027971a69419e2425c2a6c"
+  integrity sha512-3s+ed8er9ahK+zJpp9ZtuVcDoFzHNiZsPbNAAE4KXgrRHbjSqqNN6xGSXq6bq7TZIbKj4NLrLb6bJ5i+vSVjHA==
+
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -2928,6 +2942,13 @@ create-react-class@^15.5.1, create-react-class@^15.6.0:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+cross-fetch@^3.0.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
+  integrity sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==
+  dependencies:
+    node-fetch "2.6.1"
 
 cross-spawn@^4.0.0:
   version "4.0.2"
@@ -3498,14 +3519,6 @@ dotgitignore@2.1.0:
   dependencies:
     find-up "^3.0.0"
     minimatch "^3.0.4"
-
-draft-js@^0.8.0:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/draft-js/-/draft-js-0.8.1.tgz#484256414c963dd1f5309700ddada10f2aa1f6ff"
-  dependencies:
-    fbjs "^0.8.3"
-    immutable "~3.7.4"
-    object-assign "^4.1.0"
 
 duplexer2@0.0.2:
   version "0.0.2"
@@ -4165,7 +4178,12 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.0"
 
-fbjs@^0.8.1, fbjs@^0.8.3, fbjs@^0.8.4:
+fbjs-css-vars@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
+  integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
+
+fbjs@^0.8.1, fbjs@^0.8.4:
   version "0.8.9"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.9.tgz#180247fbd347dcc9004517b904f865400a0c8f14"
   dependencies:
@@ -4184,6 +4202,20 @@ fbjs@^0.8.9:
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
+
+fbjs@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-2.0.0.tgz#01fb812138d7e31831ed3e374afe27b9169ef442"
+  integrity sha512-8XA8ny9ifxrAWlyhAbexXcs3rRMtxWcs3M0lctLfB49jRDHiaxj+Mo0XxbwE7nKZYzgCFoq64FS+WFd4IycPPQ==
+  dependencies:
+    core-js "^3.6.4"
+    cross-fetch "^3.0.4"
+    fbjs-css-vars "^1.0.0"
     loose-envify "^1.0.0"
     object-assign "^4.1.0"
     promise "^7.1.1"
@@ -7537,6 +7569,11 @@ node-environment-flags@1.0.6:
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
+
+node-fetch@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-fetch@^1.0.1:
   version "1.6.3"


### PR DESCRIPTION
#### Summary

When typing Chinese in editor, it re-renders and flashes if the article includes multiple images and embedded code blocks. 
Finishing a IME composition will jump away from current focus/selection area.

See the screen recording below:

https://user-images.githubusercontent.com/6375655/121513330-51ca3200-ca1d-11eb-8878-7a4e03b716f7.mov

Since [facebook/draft-js](https://github.com/facebook/draft-js) doesn't seem to fix https://github.com/facebook/draft-js/issues/1260 in a short term. I forked facebbok/draft-js and adopt the solution proposed in https://github.com/facebook/draft-js/pull/2228.

Here is a related PR: https://github.com/twreporter/draft-js/pull/1

The changed files has been formatted by `prettier`, will create another PR to adopt prettier as code formatter in this repo.

#### Related Issue

Resolves: [[TWREPORTER-10]身為編輯，我希望在編輯有使用 image, embedded code 的文章時，每次更動文字不會因為重新載入而導致畫面跳動](https://twreporter-org.atlassian.net/browse/TWREPORTER-10?atlOrigin=eyJpIjoiODg5Yzc4MTg3Y2RkNDVhOTgyNTMzM2ZhMGE2ZjBkNzYiLCJwIjoiaiJ9)

#### Test Plan

https://github.com/twreporter/plate/pull/220
