### PR TITLE
refactor: migrate API `Entity.create`

### DIFF
--- a/fields/types/html/editor/mixins/entity-editing-block-mixin.js
+++ b/fields/types/html/editor/mixins/entity-editing-block-mixin.js
@@ -262,13 +262,14 @@ let EntityEditingBlock = (superclass) =>
       const { url, text } = value;
       const { editorState } = this.state;
       const contentState = editorState.getCurrentContent();
-      const entityKey =
+      const contentStateWithEntity =
         url !== ''
           ? contentState.createEntity(entity, 'IMMUTABLE', {
               text: text || url,
               url: url,
             })
           : null;
+      const entityKey = contentStateWithEntity.getLastCreatedEntityKey();
       this._toggleTextWithEntity(entityKey, text || url);
     }
 


### PR DESCRIPTION
This patch migrates API according to `draft-js` v0.10 api migration.

ref: https://draftjs.org/docs/v0-10-api-migration#creating-an-entity