### PR TITLE
fix: persist the username cookie

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -49,8 +49,6 @@ function signinWithUser(user, req, res, onSuccess) {
   req.session.regenerate(function() {
     req.user = user;
     req.session.userId = user.id;
-    // set user name to cookie for keystone-plugin (chatroom)
-    res.cookie('keystone.user_name', user.name);
     // if the user has a password set, store a persistence cookie to resume sessions
     if (keystone.get('cookie signin') && user.password) {
       var userToken = user.id + ':' + hash(user.password);
@@ -63,6 +61,8 @@ function signinWithUser(user, req, res, onSuccess) {
         req.session.cookie.maxAge = cookieOpts.maxAge;
       }
       res.cookie('keystone.uid', userToken, cookieOpts);
+      // set user name to cookie for keystone-plugin (chatroom)
+      res.cookie('keystone.user_name', user.name, { maxAge: cookieOpts.maxAge });
     }
     onSuccess(user);
   });
@@ -158,6 +158,7 @@ exports.signout = function(req, res, next) {
     });
     cookieOpts.maxAge = 0;
     res.clearCookie('keystone.uid', cookieOpts);
+    res.clearCookie('keystone.user_name');
     req.user = null;
     req.session.regenerate(function(err) {
       if (err) {
@@ -197,6 +198,7 @@ exports.persist = function(req, res, next) {
     });
     cookieOpts.maxAge = 0;
     res.clearCookie('keystone.uid', cookieOpts);
+    res.clearCookie('keystone.user_name');
     req.user = null;
     next();
   } else if (req.session.userId) {


### PR DESCRIPTION
This patch stores the `keystone.user_name` cookie with the same maxAge
as session.

Address [TWREPORTER-118](https://twreporter-org.atlassian.net/browse/TWREPORTER-118)