### PR TITLE
chore: bump version to v0.9.5-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 0.9.5-rc.4, 2021/9/17
+
+## Notable Changes
+
+- feat
+  - enable signout url([#206](https://github.com/twreporter/keystone/pull/204))
+
+### Commits
+* [[`b64ccb6660`](https://github.com/twreporter/keystone/commit/b64ccb6660)] - **feat**: enable signout url (Ching-Yang, Tseng)
+
 ## 0.9.5-rc.3, 2021/9/16
 
 ## Notable Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/keystone",
-  "version": "0.9.5-rc.3",
+  "version": "0.9.5-rc.4",
   "description": "Web Application Framework and Admin GUI / Content Management System built on Express.js and Mongoose",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This patch bumps version to v0.9.5-rc.4