### PR TITLE
fix: handle Unicode characters correctly when inserting tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 0.9.16, 2025/08/07
+
+### Notable Changes
+
+- fix
+  - handle Unicode characters correctly when inserting tags
+
+### Commits
+
+- [[`607431a2ed`](https://github.com/twreporter/keystone/commit/607431a2ed)] - **fix**: handle Unicode characters correctly when inserting tags (nickhsine)
+
 ## 0.9.15, 2024/08/07
 
 ### Notable Changes

--- a/fields/types/html/editor/inline-styles-processor.js
+++ b/fields/types/html/editor/inline-styles-processor.js
@@ -188,15 +188,18 @@ function convertToHtml(inlineTagMap, entityTagMap, entityMap, block) {
   });
 
   // insert tags into string, keep track of offset caused by our text insertions
+  let chars = Array.from(html); // Split into an array of actual characters (code points)
   let offset = 0;
-  orderedKeys.forEach(function(pos) {
+
+  orderedKeys.forEach(function (pos) {
     let index = Number(pos);
-    tagInsertMap[pos].forEach(function(tag) {
-      html = html.substr(0, offset + index)
-				+ tag + html.substr(offset + index);
-      offset += tag.length;
+    tagInsertMap[pos].forEach(function (tag) {
+      chars.splice(index + offset, 0, tag);
+      offset++;
     });
   });
+
+  html = chars.join('');
 
   return html;
 }

--- a/fields/types/html/editor/inline-styles-processor.js
+++ b/fields/types/html/editor/inline-styles-processor.js
@@ -7,6 +7,7 @@ import get from 'lodash/get';
 import pick from 'lodash/pick';
 import sortBy from 'lodash/sortBy';
 import template from 'lodash/template';
+import { unicodeInsert } from './utils/unicode-insert';
 
 const _ = {
   forEach,
@@ -188,13 +189,11 @@ function convertToHtml(inlineTagMap, entityTagMap, entityMap, block) {
   });
 
   // insert tags into string, keep track of offset caused by our text insertions
-  let chars = Array.from(html); // Split into an array of actual characters (code points)
   let offset = 0;
-
   orderedKeys.forEach(function (pos) {
-    let index = Number(pos);
-    tagInsertMap[pos].forEach(function (tag) {
-      chars.splice(index + offset, 0, tag);
+    let index = Number(pos) + offset;
+    tagInsertMap[pos].forEach(tag => {
+      html = unicodeInsert(html, index, tag);
       offset++;
     });
   });

--- a/fields/types/html/editor/utils/unicode-insert.js
+++ b/fields/types/html/editor/utils/unicode-insert.js
@@ -1,0 +1,5 @@
+export function unicodeInsert(str, index, insertText) {
+  const chars = Array.from(str); // code point safe
+  chars.splice(index, 0, insertText);
+  return chars.join('');
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/keystone",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "Web Application Framework and Admin GUI / Content Management System built on Express.js and Mongoose",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
### Bug 說明
編輯回報（見[完整討論串](https://twreporter.slack.com/archives/CPASS9410/p1754290421341839)），當文章段落輸入特殊字時，例如「亻因」（這是一個字，但因為怕網頁無法呈現，所以拆字表示），如果在該段落使用「註解」功能，會出現畫面異常，見下圖：


<img width="400" height="auto" alt="截圖 2025-08-06 10 51 56" src="https://github.com/user-attachments/assets/37ea12a7-335e-4893-999f-9a5ad47e96c6" />


「青狂」和「註」皆重複出現，不過「捌」卻沒有。

出錯的原因是 draft converter 在截斷文字時，使用 draft entity 提供的 offset 來算字數，但是 entity 的 offset 是根據 characters （code points）而不是 code units 來計算的，但是 draft converter 是用 `.substring()` 來斷字，而 `substring` 是根據 code units 來斷字，導致 draft converter 截斷錯位置。

### 修正方式
更改 `convertToHtml` function，改由 characters 的方式去截斷文字。
