### PR TITLE
fix: adjust offset calculation in convertToHtml function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,20 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## 0.9.19, 2026/04/10
+## 0.9.20, 2026/04/13
+
+### Notable Changes
+
+- fix
+ - adjust offset calculation in convertToHtml function
+
+### Commits
+
+- [[`eeaddb96`](https://github.com/twreporter/keystone/commit/eeaddb96)] - **fix**: adjust offset calculation in convertToHtml function (Lucien)
+
+## 0.9.19, 2026/04/10 (deprecated)
+
+> **Deprecated**: HTML editor are converted incorrectly: closing tags are inserted inside opening tags due to wrong offset calculation. Use v0.9.20 instead.
 
 ### Notable Changes
 
@@ -19,7 +32,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## 0.9.18, 2026/04/10 (deprecated)
 
-> **Deprecated**: This version was published with error file. Use v0.9.19 instead.
+> **Deprecated**: This version was published with error file. Use v0.9.20 instead.
 
 ### Notable Changes
 
@@ -28,7 +41,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## 0.9.17, 2026/04/10 (deprecated)
 
-> **Deprecated**: This version was published without building, so it is missing built files. Use v0.9.19 instead.
+> **Deprecated**: This version was published without building, so it is missing built files. Use v0.9.20 instead.
 
 ### Notable Changes
 

--- a/fields/types/html/editor/inline-styles-processor.js
+++ b/fields/types/html/editor/inline-styles-processor.js
@@ -194,7 +194,7 @@ function convertToHtml(inlineTagMap, entityTagMap, entityMap, block) {
     let index = Number(pos) + offset;
     tagInsertMap[pos].forEach(tag => {
       html = unicodeInsert(html, index, tag);
-      offset++;
+      offset += Array.from(tag).length;
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/keystone",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "description": "Web Application Framework and Admin GUI / Content Management System built on Express.js and Mongoose",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
# Issue
Root cause: `unicodeInsert` rebuilds the string by splitting it into individual characters with `Array.from(str)`. After inserting a tag like `<a target="_blank" href="...">`, subsequent positions in the character array shift by the tag's full character count — but the code was only adding 1 to the offset per insertion. This caused closing tags (and any subsequent tags) to be placed inside previously inserted tags.

`Array.from(tag).length` is used instead of `tag.length` to stay consistent with the code-point-safe approach already used in `unicodeInsert`.

cc @nickhsine @Aylie-Chou 

# Notice
<!-- Related notice or note for this PR -->

# Dependency
<!-- Related dependency of this PR -->
